### PR TITLE
now using conda is optional

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -4,40 +4,44 @@
 
 ### 1.1 Manually
 
+Using `conda` as the package manager is not necessary nor provides any advantages (of course virtual environment are necessary). Hence, if you like, you can install dependencies via `conda`. Note that only few of the dependencies are available on `conda` channels and you still need to use `pip`.
+
+From now on, the phrase "*if conda*" assumes if you are using `conda` for your packages. Otherwise, `pip` only is inferred.
+
 **tip:** You can use `mamba` to hugely speed up the installation process. If you don't want to, replace all instances of the `mamba` with `conda` in following steps.
 
-#### 1.1.1 Create a `conda` env
+#### \[Optional\] 1.1.1 Create a `conda` env
 
-Well all packages gonna be here.
->`conda create --name cvfe python=3.11.0 -y`
+> if conda: `conda create --name cvfe python=3.11.0 -y`
 
-#### 1.1.2 Activate the new environment
+#### \[Optional\] 1.1.2 Activate the new environment
 
 Make sure you activate this environment right away:
->`conda activate cvfe`
+> if conda: `conda activate cvfe`
 
 #### 1.1.3 Update `pip`
 
 You should have at least `pip >= 23.1.2`
->`pip install --upgrade pip`
+> `pip install --upgrade pip`
 
-#### 1.1.4 Pin the Python version
+#### \[Optional\] 1.1.4 Pin the Python version
 
 When using `conda`, `mamba` and so on, it might update the Python to its latest version. We should prevent that by pinning the Python version in the `conda` environment. To do so:
 
-`echo "python 3.11.0" >>$CONDA_PREFIX/conda-meta/pinned`
+> if conda: `echo "python 3.11.0" >>$CONDA_PREFIX/conda-meta/pinned`
 
 #### 1.1.5 Install Processing Dependencies
 
 We need `pandas` and `numpy` and some others, but installing `pandas` will install all those needed.
 
-> `mamba install pandas`
+> `pip install pandas`
+> if conda: `mamba install pandas`
 
 #### 1.1.5 Install data extraction dependencies
 
->1. `mamba install -c conda-forge xmltodict>=0.13.0 -y`
->2. `pip install pikepdf>=5.1.5`
->3. `pip install pypdf2>=2.2.1`
+> 1. `pip install xmltodict>=0.13.0`. if conda: `mamba install -c conda-forge xmltodict>=0.13.0 -y`
+> 2. `pip install pikepdf>=5.1.5`
+> 3. `pip install pypdf2>=2.2.1`
 
 #### 1.1.6 Install API libs
 
@@ -49,7 +53,7 @@ These libraries (the main one is FastAPI) are not for the ML part and only are h
 >4. `pip install uvicorn>=0.18.2`
 >5. `pip install python-multipart>=0.0.5`
 
-*\[Optional\]* For making it online using `ngrok`:
+*\[Optional\]* For making it online (only for development) using `ngrok`:
 
 1. `pip install pydantic-settings`
 2. `pip install pyngrok`

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -43,8 +43,11 @@ dependencies:
   - pip:
       - annotated-types==0.5.0
       - anyio==3.7.1
+      - click==8.1.6
       - deprecation==2.1.0
       - fastapi==0.100.0
+      - gunicorn==21.2.0
+      - h11==0.14.0
       - idna==3.4
       - lxml==4.9.3
       - packaging==23.1
@@ -53,8 +56,14 @@ dependencies:
       - pip==23.2.1
       - pydantic==2.0.3
       - pydantic-core==2.3.0
+      - pydantic-settings==2.0.2
+      - pyngrok==6.0.0
       - pypdf2==3.0.1
+      - python-dotenv==1.0.0
+      - python-multipart==0.0.6
+      - pyyaml==6.0.1
       - sniffio==1.3.0
       - starlette==0.27.0
       - typing-extensions==4.7.1
+      - uvicorn==0.23.1
 prefix: /home/nik/anaconda3/envs/cvfe


### PR DESCRIPTION
Note that there is no need to change the codebase and only setup guide and accompanying `conda` environment file needed to be updated in case anyone wanted to use `conda`/`pip`.