### PR TITLE
Enable image to be compatible with GitHub Container Registry (ghcr)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,3 @@ COPY . /app/
 
 # install the package itself (`cvfe` package)
 RUN pip install .
-
-# run FastAPI app with Uvicorn as the main application
-CMD ["python", "-m", "cvfe.main.py", "--bind", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.11-slim
 
 # set the maintainer label
 LABEL maintainer="Nikan Doosti <nikan.doosti@outlook.com>"
+# connect the container image to the repository
+LABEL org.opencontainers.image.source https://github.com/nikronic/canada-visa-form-extraction
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ We have provided a `yml` file (`conda_env.yml`) for ease of install using `conda
 
 #### 1.1.3 Using Docker
 
+**Official Image**:
+The easiest way is to just pull the official image from GitHub Container Registry:
+> `docker pull ghcr.io/nikronic/cvfe:DESIRED_VERSION`
+
+For instance, for the version `v0.2.1` (`cat VERSION`), you can pull `docker pull ghcr.io/nikronic/cvfe:v0.2.1`.
+
+Then for running it, use:
+> `docker run -p YOUR_HOST_PORT:CONTAINER_PORT ghcr.io/nikronic/cvfe:DESIRED_VERSION python -m cvfe.main --bind 0.0.0.0 --port CONTAINER_PORT`
+
+For example:
+> `docker run -p 9999:8000 ghcr.io/nikronic/cvfe:v0.2.1 python -m cvfe.main --bind 0.0.0.0 --port 8000`
+
+*note:* All the images can be found on the [repo packages](https://github.com/Nikronic/canada-visa-form-extraction/pkgs/container/cvfe).
+
+**Manual Image**:
 We have provided a `Dockerfile` for ease of install using `docker`. Please use:
 > `docker build -t cvfe .`
 


### PR DESCRIPTION
- Connected the container to the repo
- remove server initialization command
- add setup for using the official image (`cvfe:VERSION`) on `ghcr` (available at [CVFE - Packages](https://github.com/users/Nikronic/packages/container/package/cvfe))