### PR TITLE
now only build package on push to `main`

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,7 @@
 name: Docker Image CI
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
 
 env:


### PR DESCRIPTION
Previously, changes in a pull request would also trigger this which is wrong. Only merged PRs which are necessarily push commits to `main` should trigger building and publishing to `ghcr` as it should only contain production code.