### PR TITLE
build docker image only on release

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,8 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: [ "main" ]
+  release:
+    types: [created]
 
 env:
   IMAGE_NAME: cvfe


### PR DESCRIPTION
Previously docker image was being build at every PR which was not correct!!!

From now on, docker image is only and only built if a release has been published.

*note:* for previously mentioned reasons (personal confirmation!), I do release *manually*, hence both `PyPI` package and `docker` image and also newly `sphinx` documentations are only built when a new release happens.