### PR TITLE
Docs now only trigger on `release-v*` branch PRs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,9 +1,9 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on any release
-  release:
-      types: [created]
+  pull_request:
+    types:
+      - closed
   
   workflow_dispatch:
 
@@ -24,6 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Check if PR is from release branch to main
+        id: check-pr
+        run: |
+          if [[ ${{ github.event.pull_request.base.ref }} == "main" && ${{ github.event.pull_request.head.ref }} =~ ^release-v.*$ ]]; then
+            echo "PR is from a release branch to main."
+            echo "::set-output name=trigger_deploy::true"
+          else
+            echo "PR is not from a release branch to main."
+            echo "::set-output name=trigger_deploy::false"
+          fi
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -39,5 +49,6 @@ jobs:
         with:
           path: 'docs/build/html'
       - name: Deploy to GitHub Pages
+        if: steps.check-pr.outputs.trigger_deploy == 'true'
         id: deployment
         uses: actions/deploy-pages@v2


### PR DESCRIPTION
Because of the following issue, I have to change the trigger event:
![image](https://github.com/Nikronic/canada-visa-form-extraction/assets/32401852/291db395-d77c-481d-98e5-ecf48cb25ba2)

So, since the tag name convention follows `v*` and for some unknown reason GitHub wants to publish to Pages via a branch name `v*` instead of following my branch name `release-v*` associated with those tags.

So, from now on, I check if the PR is coming from a release branch (`release-v*`) and if only that, I deploy to pages.

*Note: all these could have been fixed if I only removed all protection rules in *Environments* setting. Yet since it is not secure, I would rather go through this nonsense.