### PR TITLE
add `pre-commit` for formatting (black and isort)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+-   repo: https://github.com/pycqa/isort
+    rev: 5.13.2  # Use the ref you want to point at
+    hooks:
+    -   id: isort
+-   repo: https://github.com/psf/black
+    rev: 23.12.1  # Use the ref you want to point at
+    hooks:
+    - id: black
+      language_version: python3.10  # Should match the python version you're using

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -28,20 +28,27 @@ dependencies:
       - annotated-types==0.6.0
       - anyio==4.2.0
       - certifi==2023.11.17
+      - cfgv==3.4.0
       - charset-normalizer==3.3.2
       - click==8.1.7
       - cvfe==0.2.12
       - deprecated==1.2.14
+      - distlib==0.3.8
       - fastapi==0.108.0
+      - filelock==3.13.1
       - gunicorn==21.2.0
       - h11==0.14.0
+      - identify==2.5.33
       - idna==3.6
       - lxml==5.0.0
+      - nodeenv==1.8.0
       - numpy==1.26.3
       - packaging==23.2
       - pandas==2.1.4
       - pikepdf==8.11.2
       - pillow==10.2.0
+      - platformdirs==4.1.0
+      - pre-commit==3.6.0
       - pydantic==2.5.3
       - pydantic-core==2.14.6
       - pydantic-settings==2.1.0
@@ -60,6 +67,7 @@ dependencies:
       - tzdata==2023.4
       - urllib3==2.1.0
       - uvicorn==0.25.0
+      - virtualenv==20.25.0
       - wrapt==1.16.0
       - xmltodict==0.13.0
 prefix: /home/nikan/miniforge3/envs/cvfe

--- a/cvfe/api/__init__.py
+++ b/cvfe/api/__init__.py
@@ -1,6 +1,4 @@
-# helpers
 import logging
-
 
 # set logger
 logger = logging.getLogger(__name__)

--- a/cvfe/api/apps.py
+++ b/cvfe/api/apps.py
@@ -1,11 +1,9 @@
-# core
-from gunicorn.app.base import BaseApplication
-from pydantic_settings import BaseSettings
-# helpers
-from typing import Callable, ClassVar
 import logging
 import os
+from typing import Callable, ClassVar
 
+from gunicorn.app.base import BaseApplication
+from pydantic_settings import BaseSettings
 
 # config logger
 logger = logging.getLogger(__name__)
@@ -31,10 +29,12 @@ class StandaloneApplication(BaseApplication):
         super().__init__()
 
     def load_config(self):
-        """Loads only those options that are valid
-        """
-        config = {key: value for key, value in self.options.items()
-                  if key in self.cfg.settings and value is not None}
+        """Loads only those options that are valid"""
+        config = {
+            key: value
+            for key, value in self.options.items()
+            if key in self.cfg.settings and value is not None
+        }
         for key, value in config.items():
             self.cfg.set(key.lower(), value)
 
@@ -48,18 +48,17 @@ def init_webhooks(base_url):
 
 
 class Settings(BaseSettings):
-    BASE_URL: ClassVar[str] = ''
-    USE_NGROK: ClassVar[bool] = os.environ.get('USE_NGROK', 'False') == 'True'
+    BASE_URL: ClassVar[str] = ""
+    USE_NGROK: ClassVar[bool] = os.environ.get("USE_NGROK", "False") == "True"
 
-def init_ngrok(
-        host: str,
-        port: int):
+
+def init_ngrok(host: str, port: int):
     # pyngrok should only ever be installed or initialized in a dev environment when this flag is set
     from pyngrok import ngrok
 
     # Open a ngrok tunnel to the dev server
     public_url = ngrok.connect(port).public_url
-    logger.info(f'ngrok tunnel \"{public_url}\" -> \"http://{host}:{port}\"')
+    logger.info(f'ngrok tunnel "{public_url}" -> "http://{host}:{port}"')
 
     # Update any base URLs or webhooks to use the public ngrok URL
     Settings.BASE_URL = public_url

--- a/cvfe/api/convert/__init__.py
+++ b/cvfe/api/convert/__init__.py
@@ -1,5 +1,4 @@
-# helpers
 from pathlib import Path
 
 # all files dealt by APIs will be saved here (temporary)
-BASE_SOURCE_DIR: Path = Path('temp/encrypted/')
+BASE_SOURCE_DIR: Path = Path("temp/encrypted/")

--- a/cvfe/api/convert/adobe_xfa.py
+++ b/cvfe/api/convert/adobe_xfa.py
@@ -1,136 +1,127 @@
-# Ours: data
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import fastapi
+import pandas as pd
+import requests
+from fastapi.encoders import jsonable_encoder
+
+from cvfe.api.convert import BASE_SOURCE_DIR
 from cvfe.data import functional
+from cvfe.data.constant import DocTypes
 from cvfe.data.preprocessor import (
+    CanadaDataframePreprocessor,
     CopyFile,
     FileTransformCompose,
     MakeContentCopyProtectedMachineReadable,
-    CanadaDataframePreprocessor)
-from cvfe.data.constant import DocTypes
-# Ours: API
-from cvfe.api.convert import BASE_SOURCE_DIR
-# API
-import fastapi
-import requests
-from fastapi.encoders import jsonable_encoder
-# helpers
-from typing import Optional
-from pathlib import Path
-import pandas as pd
-import logging
-import sys
-import os
-
+)
 
 # config logger
 logger = logging.getLogger(__name__)
 
 
 # FastAPI router to be used by the FastAPI app
-router = fastapi.APIRouter(
-    prefix='/cvfe/v1/convert/adobe_xfa',
-    tags=['adobe_xfa']
-)
+router = fastapi.APIRouter(prefix="/cvfe/v1/convert/adobe_xfa", tags=["adobe_xfa"])
 
 
 def process(src_dir: Path):
     # path to the output decrypted pdf
-    dst_dir: Path = src_dir.parts[0] / Path('decrypted/')
+    dst_dir: Path = src_dir.parts[0] / Path("decrypted/")
     # main code
-    logger.info('↓↓↓ Starting data extraction ↓↓↓')
+    logger.info("↓↓↓ Starting data extraction ↓↓↓")
     # Canada protected PDF to make machine readable and skip other files
     compose = {
-        CopyFile(mode='cf'): '.csv',
-        CopyFile(mode='cf'): '.txt',
-        MakeContentCopyProtectedMachineReadable(): '.pdf'
+        CopyFile(mode="cf"): ".csv",
+        CopyFile(mode="cf"): ".txt",
+        MakeContentCopyProtectedMachineReadable(): ".pdf",
     }
     file_transform_compose = FileTransformCompose(transforms=compose)
     functional.process_directory(
         src_dir=src_dir.as_posix(),
         dst_dir=dst_dir.as_posix(),
         compose=file_transform_compose,
-        file_pattern='*')
-    logger.info('↑↑↑ Finished data extraction ↑↑↑')
+        file_pattern="*",
+    )
+    logger.info("↑↑↑ Finished data extraction ↑↑↑")
 
-    logger.info('↓↓↓ Starting data loading ↓↓↓')
+    logger.info("↓↓↓ Starting data loading ↓↓↓")
     # convert PDFs to pandas dataframes
     src_dir = dst_dir.as_posix()
     dataframe = pd.DataFrame()
     for dirpath, dirnames, all_filenames in os.walk(src_dir):
-
         # filter all_filenames
         filenames = all_filenames
         if filenames:
             files = [os.path.join(dirpath, fname) for fname in filenames]
             # applicant form
-            logger.info('↓↓↓ Starting to process 5257E ↓↓↓')
-            in_fname = [f for f in files if '5257' in f][0]
+            logger.info("↓↓↓ Starting to process 5257E ↓↓↓")
+            in_fname = [f for f in files if "5257" in f][0]
             df_preprocessor = CanadaDataframePreprocessor()
             if len(in_fname) != 0:
                 dataframe_applicant = df_preprocessor.file_specific_basic_transform(
-                    path=in_fname,
-                    type=DocTypes.canada_5257e)
-            logger.info('↑↑↑ Finished processing 5257E ↑↑↑')
+                    path=in_fname, type=DocTypes.canada_5257e
+                )
+            logger.info("↑↑↑ Finished processing 5257E ↑↑↑")
             # applicant family info
-            logger.info('↓↓↓ Starting to process 5645E ↓↓↓')
-            in_fname = [f for f in files if '5645' in f][0]
+            logger.info("↓↓↓ Starting to process 5645E ↓↓↓")
+            in_fname = [f for f in files if "5645" in f][0]
             if len(in_fname) != 0:
                 dataframe_family = df_preprocessor.file_specific_basic_transform(
-                    path=in_fname,
-                    type=DocTypes.canada_5645e)
-            logger.info('↑↑↑ Finished processing 5645E ↑↑↑')
+                    path=in_fname, type=DocTypes.canada_5645e
+                )
+            logger.info("↑↑↑ Finished processing 5645E ↑↑↑")
 
             # final dataframe: concatenate common forms and label column wise
             dataframe = pd.concat(
-                objs=[
-                    dataframe_applicant,
-                    dataframe_family],
+                objs=[dataframe_applicant, dataframe_family],
                 axis=1,
-                verify_integrity=True)
+                verify_integrity=True,
+            )
         # logging
-        logger.info(f'Processed the data point')
-    logger.info('↑↑↑ Finished data loading ↑↑↑')
+        logger.info(f"Processed the data point")
+    logger.info("↑↑↑ Finished data loading ↑↑↑")
     return dataframe
 
 
-@router.post(
-    '/',
-    status_code=fastapi.status.HTTP_200_OK,
-    tags=['adobe_xfa'])
+@router.post("/", status_code=fastapi.status.HTTP_200_OK, tags=["adobe_xfa"])
 async def convert(
     form_5257: fastapi.UploadFile,
     form_5645: fastapi.UploadFile,
-    post_url: Optional[str] = None):
-
+    post_url: Optional[str] = None,
+):
     try:
         # save files to disk
-        input_path: Path = BASE_SOURCE_DIR / Path('x/')
+        input_path: Path = BASE_SOURCE_DIR / Path("x/")
         # create the path if does not exist
         input_path.mkdir(parents=True, exist_ok=True)
-        with open(input_path / Path('5257.pdf'), 'wb') as f:
+        with open(input_path / Path("5257.pdf"), "wb") as f:
             contents_form_5257 = await form_5257.read()
             f.write(contents_form_5257)
-        with open(input_path / Path('5645.pdf'), 'wb') as f:
+        with open(input_path / Path("5645.pdf"), "wb") as f:
             contents_form_5645 = await form_5645.read()
             f.write(contents_form_5645)
     except Exception as error:
         logger.exception(error)
         e = sys.exc_info()[1]
         raise fastapi.HTTPException(
-            status_code=fastapi.status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
-            detail=str(e))
+            status_code=fastapi.status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, detail=str(e)
+        )
     try:
         data: pd.DataFrame = process(src_dir=BASE_SOURCE_DIR)
 
-        logger.info('Process finished')
+        logger.info("Process finished")
         response = [data.iloc[0].to_dict()]
-    
+
     except Exception as error:
         logger.exception(error)
         e = sys.exc_info()[1]
         raise fastapi.HTTPException(
-            status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-            detail=str(e))
-    
+            status_code=fastapi.status.HTTP_400_BAD_REQUEST, detail=str(e)
+        )
+
     try:
         response_status_code: int = -1
         # if third-party url is provided, send post request to that
@@ -138,23 +129,21 @@ async def convert(
             # make response jsonable
             jsonable_response = jsonable_encoder(response)
             # send the response to create the item in DB
-            post_response = requests.post(
-                url=post_url,
-                json=jsonable_response
-            )
+            post_response = requests.post(url=post_url, json=jsonable_response)
             response_status_code = post_response.status_code
-            logger.info(f'post response code {post_response.status_code}')
+            logger.info(f"post response code {post_response.status_code}")
 
             # raise exception if bad status code
             if not post_response.ok:
                 raise fastapi.HTTPException(
-                    status_code=post_response.status_code,
-                    detail=post_response.text)
+                    status_code=post_response.status_code, detail=post_response.text
+                )
         return response
-    
+
     except Exception as error:
         logger.exception(error)
         e = sys.exc_info()[1]
         raise fastapi.HTTPException(
             status_code=response_status_code,
-            detail=str(e) if type(e) == str else str(e.detail))
+            detail=str(e) if type(e) == str else str(e.detail),
+        )

--- a/cvfe/configs/__init__.py
+++ b/cvfe/configs/__init__.py
@@ -1,13 +1,12 @@
 # ref: https://stackoverflow.com/a/50797410/18971263
 import pathlib
 
-
 # path to all config/db files
 parent_dir = pathlib.Path(__file__).parent
-DATA_DIR = parent_dir / 'data'
+DATA_DIR = parent_dir / "data"
 
 
-CANADA_COUNTRY_CODE_TO_NAME = DATA_DIR / 'canada-country-code-to-name.csv'
+CANADA_COUNTRY_CODE_TO_NAME = DATA_DIR / "canada-country-code-to-name.csv"
 """Canada visa form country code to name
 
 Note:
@@ -16,7 +15,7 @@ Note:
     their forms.
 """
 
-IRAN_PROVINCE_TO_CITY = DATA_DIR / 'iran-province-to-city.csv'
+IRAN_PROVINCE_TO_CITY = DATA_DIR / "iran-province-to-city.csv"
 """Iran city to province name
 
 Note:

--- a/cvfe/data/constant.py
+++ b/cvfe/data/constant.py
@@ -1,11 +1,20 @@
 __all__ = [
-    'CANADA_5257E_KEY_ABBREVIATION', 'CANADA_5645E_KEY_ABBREVIATION', 'CANADA_5257E_VALUE_ABBREVIATION',
-    'CANADA_5257E_DROP_COLUMNS', 'CANADA_5645E_DROP_COLUMNS', 'DocTypes',
-    'CanadaCutoffTerms', 'CanadaFillna', 'DATEUTIL_DEFAULT_DATETIME', 'T0',
-
+    "CANADA_5257E_KEY_ABBREVIATION",
+    "CANADA_5645E_KEY_ABBREVIATION",
+    "CANADA_5257E_VALUE_ABBREVIATION",
+    "CANADA_5257E_DROP_COLUMNS",
+    "CANADA_5645E_DROP_COLUMNS",
+    "DocTypes",
+    "CanadaCutoffTerms",
+    "CanadaFillna",
+    "DATEUTIL_DEFAULT_DATETIME",
+    "T0",
     # Data Enums shared all over the place
-    'CustomNamingEnum', 'CanadaMarriageStatus',
-    'CanadaContactRelation', 'CanadaResidencyStatus', 'Sex',
+    "CustomNamingEnum",
+    "CanadaMarriageStatus",
+    "CanadaContactRelation",
+    "CanadaResidencyStatus",
+    "Sex",
 ]
 
 import datetime
@@ -13,63 +22,60 @@ from enum import Enum, auto
 from types import DynamicClassAttribute
 from typing import List
 
-
 # DICTIONARY
 CANADA_5257E_KEY_ABBREVIATION = {
-    'Page': 'P',
-    'PersonalDetails': 'PD',
-    'CountryWhereApplying': 'CWA',
-    'MaritalStatus': 'MS',
-    'Section': 'Sec',
-    'ContactInformation': 'CI',
-    'DetailsOfVisit': 'DOV',
-    'Education': 'Edu',
-    'PageWrapper': 'PW',
-    'Occupation': 'Occ',
-    'BackgroundInfo': 'BGI',
-    'Current': 'Curr',
-    'Previous': 'Prev',
-    'Marriage': 'Marr',
-    'Married': 'Marr',
-    'Previously': 'Prev',
-    'Passport': 'Psprt',
-    'Language': 'Lang',
-    'Address': 'Addr',
-    'contact': 'cntct',
-    'Contact': 'cntct',
-    'Resident': 'Resi',
-    'Phone': 'Phn',
-    'Number': 'Num',
-    'Purpose': 'Prps',
-    'HowLongStay': 'HLS',
-    'Signature': 'Sign',
-
+    "Page": "P",
+    "PersonalDetails": "PD",
+    "CountryWhereApplying": "CWA",
+    "MaritalStatus": "MS",
+    "Section": "Sec",
+    "ContactInformation": "CI",
+    "DetailsOfVisit": "DOV",
+    "Education": "Edu",
+    "PageWrapper": "PW",
+    "Occupation": "Occ",
+    "BackgroundInfo": "BGI",
+    "Current": "Curr",
+    "Previous": "Prev",
+    "Marriage": "Marr",
+    "Married": "Marr",
+    "Previously": "Prev",
+    "Passport": "Psprt",
+    "Language": "Lang",
+    "Address": "Addr",
+    "contact": "cntct",
+    "Contact": "cntct",
+    "Resident": "Resi",
+    "Phone": "Phn",
+    "Number": "Num",
+    "Purpose": "Prps",
+    "HowLongStay": "HLS",
+    "Signature": "Sign",
     # more meaningful keys
-    'GovPosition.Choice': 'witnessIllTreat',
-    'Occ.Choice': 'politicViol',
-    'BGI3.Choice': 'criminalRec',
-    'Details.VisaChoice3': 'PrevApply',
-    'BGI2.VisaChoice2': 'refuseDeport',
-    'BGI2.VisaChoice1': 'noAuthStay',
-    'backgroundInfoCalc': 'otherThanMedic'
+    "GovPosition.Choice": "witnessIllTreat",
+    "Occ.Choice": "politicViol",
+    "BGI3.Choice": "criminalRec",
+    "Details.VisaChoice3": "PrevApply",
+    "BGI2.VisaChoice2": "refuseDeport",
+    "BGI2.VisaChoice1": "noAuthStay",
+    "backgroundInfoCalc": "otherThanMedic",
 }
 """Dict of abbreviation used to shortening length of KEYS in XML to CSV conversion
 
 """
 
 CANADA_5645E_KEY_ABBREVIATION = {
-    'page': 'p',
-    'Applicant': 'App',
-    'Mother': 'Mo',
-    'Father': 'Fa',
-    'Section': 'Sec',
-    'Spouse': 'Sps',
-    'Child': 'Chd',
-    'Address': 'Addr',
-    'Occupation': 'Occ',
-    'Yes': 'Accomp',
-    'Relationship': 'Rel',
-
+    "page": "p",
+    "Applicant": "App",
+    "Mother": "Mo",
+    "Father": "Fa",
+    "Section": "Sec",
+    "Spouse": "Sps",
+    "Child": "Chd",
+    "Address": "Addr",
+    "Occupation": "Occ",
+    "Yes": "Accomp",
+    "Relationship": "Rel",
 }
 """Dict of abbreviation used to shortening length of KEYS in XML to CSV conversion
 
@@ -77,18 +83,18 @@ CANADA_5645E_KEY_ABBREVIATION = {
 
 # see #29
 DATEUTIL_DEFAULT_DATETIME = {
-    'day': 1,  # no reason for this value (CluelessClown)
-    'month': 1,  # no reason for this value (CluelessClown)
-    'year': datetime.MINYEAR
+    "day": 1,  # no reason for this value (CluelessClown)
+    "month": 1,  # no reason for this value (CluelessClown)
+    "year": datetime.MINYEAR,
 }
 """A default date for the ``dateutil.parser.parse`` function when some part of date is not provided
 
 """
 
 CANADA_5257E_VALUE_ABBREVIATION = {
-    'BIOMETRIC ENROLMENT': 'Bio',
-    '223': 'IRAN',
-    '045': 'TURKEY',
+    "BIOMETRIC ENROLMENT": "Bio",
+    "223": "IRAN",
+    "045": "TURKEY",
 }
 """Dict of abbreviation used to shortening length of VALUES in XML to CSV conversion
 """
@@ -96,10 +102,9 @@ CANADA_5257E_VALUE_ABBREVIATION = {
 # LIST
 CANADA_5257E_DROP_COLUMNS = [
     # newly rolled back data
-
     # 'P1.PD.DOBDay', 'P1.PD.DOBMonth', 'P1.PrevSpouseAge', 'P1.PD.Name.FamilyName',
     # 'P1.PD.Name.GivenName', 'P1.PD.PrevCOR.Row2.Other', 'P1.MS.SecA.FamilyName',
-    # 'P1.MS.SecA.GivenName', 'P2.MS.SecA.PrevSpouseDOB.DOBMonth', 
+    # 'P1.MS.SecA.GivenName', 'P2.MS.SecA.PrevSpouseDOB.DOBMonth',
     # 'P2.MS.SecA.PrevSpouseDOB.DOBDay', 'P2.MS.SecA.Psprt.PsprtNum.PsprtNum',
     # 'P2.natID.natIDdocs.DocNum.DocNum', 'P2.MS.SecA.Langs.languages.lov',
     # 'P3.Occ.OccRow1.Employer', 'P3.Occ.OccRow2.Employer', 'P3.Occ.OccRow3.Employer',
@@ -112,9 +117,9 @@ CANADA_5257E_DROP_COLUMNS = [
     # 'P3.Edu.Edu_Row1.ToMonth', 'P3.Edu.Edu_Row1.School', 'P3.Edu.Edu_Row1.CityTown',
     # 'P3.Edu.Edu_Row1.ProvState', 'P3.Occ.OccRow1.FromMonth', 'P3.Occ.OccRow1.ToMonth',
     # 'P3.Occ.OccRow1.CityTown.CityTown', 'P3.Occ.OccRow1.ProvState', 'P3.Occ.OccRow2.FromMonth',
-    # 'P3.Occ.OccRow2.ToMonth', 'P3.Occ.OccRow2.CityTown.CityTown', 'P3.Occ.OccRow2.ProvState', 
+    # 'P3.Occ.OccRow2.ToMonth', 'P3.Occ.OccRow2.CityTown.CityTown', 'P3.Occ.OccRow2.ProvState',
     # 'P3.Occ.OccRow3.FromMonth', 'P3.Occ.OccRow3.ToMonth', 'P3.Occ.OccRow3.CityTown.CityTown',
-    # 'P3.Occ.OccRow3.ProvState', 'P3.DOV.cntcts_Row1.AddrInCanada.AddrInCanada', 
+    # 'P3.Occ.OccRow3.ProvState', 'P3.DOV.cntcts_Row1.AddrInCanada.AddrInCanada',
     # 'P2.CI.cntct.FaxEmail.Email', 'P2.CI.cntct.AddrRow1.POBox.POBox',
     # 'P2.CI.cntct.AddrRow1.Apt.AptUnit', 'P2.CI.cntct.AddrRow1.StreetNum.StreetNum',
     # 'P2.CI.cntct.AddrRow1.Streetname.Streetname', 'P2.CI.cntct.AddrRow2.ProvinceState.ProvinceState',
@@ -140,21 +145,32 @@ CANADA_5257E_DROP_COLUMNS = [
     # 'P2.USCard.usCarddocs.ExpiryDate', 'P2.USCard.usCarddocs.DocNum.DocNum',
     # 'P2.MS.SecA.DateLastValidated.DateCalc', 'P2.MS.SecA.DateLastValidated.Day',
     # 'P2.MS.SecA.DateLastValidated.Year', 'P2.MS.SecA.DateLastValidated.Month',
-
-    'ns0:datasets.@xmlns:ns0', 'P1.Header.CRCNum', 'P1.FormVersion',
-    'P1.PD.UCIClientID', 'P1.PD.SecHeader.@ns0:dataNode',
-    'P1.PD.CurrCOR.Row1.@ns0:dataNode', 'P1.PD.PrevCOR.Row1.@ns0:dataNode',
-    'P1.PD.CWA.Row1.@ns0:dataNode', 'P1.PD.ApplicationValidatedFlag',
-    'P2.MS.SecA.SecHeader.@ns0:dataNode', 
-    'P2.MS.SecA.PsprtSecHeader.@ns0:dataNode',
-    'P2.MS.SecA.Langs.languagesHeader.@ns0:dataNode', 'P2.natID.SecHeader.@ns0:dataNode',
-    'P2.USCard.SecHeader.@ns0:dataNode', 'P2.USCard.SecHeader.@ns0:dataNode',
-    'P2.CI.cntct.cntctInfoSecHeader.@ns0:dataNode', 
-    'P3.SecHeader_DOV.@ns0:dataNode',
-    'P3.Edu.Edu_SecHeader.@ns0:dataNode',
-    'P3.Occ.SecHeader_CurrOcc.@ns0:dataNode', 'P3.BGI_SecHeader.@ns0:dataNode',
-    'P3.Sign.Consent0.Choice', 'P3.Sign.hand.@ns0:dataNode', 'P3.Sign.TextField2',
-    'P3.Disclosure.@ns0:dataNode', 'P3.ReaderInfo', 'Barcodes.@ns0:dataNode',
+    "ns0:datasets.@xmlns:ns0",
+    "P1.Header.CRCNum",
+    "P1.FormVersion",
+    "P1.PD.UCIClientID",
+    "P1.PD.SecHeader.@ns0:dataNode",
+    "P1.PD.CurrCOR.Row1.@ns0:dataNode",
+    "P1.PD.PrevCOR.Row1.@ns0:dataNode",
+    "P1.PD.CWA.Row1.@ns0:dataNode",
+    "P1.PD.ApplicationValidatedFlag",
+    "P2.MS.SecA.SecHeader.@ns0:dataNode",
+    "P2.MS.SecA.PsprtSecHeader.@ns0:dataNode",
+    "P2.MS.SecA.Langs.languagesHeader.@ns0:dataNode",
+    "P2.natID.SecHeader.@ns0:dataNode",
+    "P2.USCard.SecHeader.@ns0:dataNode",
+    "P2.USCard.SecHeader.@ns0:dataNode",
+    "P2.CI.cntct.cntctInfoSecHeader.@ns0:dataNode",
+    "P3.SecHeader_DOV.@ns0:dataNode",
+    "P3.Edu.Edu_SecHeader.@ns0:dataNode",
+    "P3.Occ.SecHeader_CurrOcc.@ns0:dataNode",
+    "P3.BGI_SecHeader.@ns0:dataNode",
+    "P3.Sign.Consent0.Choice",
+    "P3.Sign.hand.@ns0:dataNode",
+    "P3.Sign.TextField2",
+    "P3.Disclosure.@ns0:dataNode",
+    "P3.ReaderInfo",
+    "Barcodes.@ns0:dataNode",
 ]
 """List of columns to be dropped before doing any preprocessing
 
@@ -167,11 +183,17 @@ CANADA_5645E_DROP_COLUMNS = {
     # newly rolled back data
     # 'p1.SecA.App.AppDOB', 'p1.SecA.App.AppCOB', 'p1.SecA.App.AppOcc',
     # 'p1.SecA.Sps.ChdMStatus', 'p1.SecA.App.AppOcc',
-
-    'xfa:datasets.@xmlns:xfa', 'p1.SecA.Title.@xfa:dataNode', 'p1.SecB.SecBsignature',
-    'p1.SecB.SecBdate', 'p1.SecC.Title.@xfa:dataNode', 'p1.SecA.SecAsignature',
-    'p1.SecA.SecAdate', 'p1.SecB.Title.@xfa:dataNode', 'p1.SecC.SecCsignature',
-    'p1.SecC.Subform2.@xfa:dataNode',  'formNum',
+    "xfa:datasets.@xmlns:xfa",
+    "p1.SecA.Title.@xfa:dataNode",
+    "p1.SecB.SecBsignature",
+    "p1.SecB.SecBdate",
+    "p1.SecC.Title.@xfa:dataNode",
+    "p1.SecA.SecAsignature",
+    "p1.SecA.SecAdate",
+    "p1.SecB.Title.@xfa:dataNode",
+    "p1.SecC.SecCsignature",
+    "p1.SecC.Subform2.@xfa:dataNode",
+    "formNum",
 }
 """List of columns to be dropped before doing any preprocessing
 
@@ -185,22 +207,21 @@ Note:
 class DocTypes(Enum):
     """Contains all document types which can be used to customize ETL steps for each document type
 
-    Members follow the ``<country_name>_<document_type>`` naming convention. The value 
+    Members follow the ``<country_name>_<document_type>`` naming convention. The value
     and its order are meaningless.
     """
-    canada = 1        # referring to all Canada docs in general
+
+    canada = 1  # referring to all Canada docs in general
     canada_5257e = 2  # application for visitor visa (temporary resident visa)
     canada_5645e = 3  # Family information
     canada_label = 4  # containing labels
 
 
 class CanadaCutoffTerms(Enum):
-    """Dict of cut off terms for different files that is can be used with :func:`dict_summarizer <vizard.data.functional.dict_summarizer>`
+    """Dict of cut off terms for different files that is can be used with :func:`dict_summarizer <vizard.data.functional.dict_summarizer>`"""
 
-    """
-
-    ca5645e = 'IMM_5645'
-    ca5257e = 'form1'
+    ca5645e = "IMM_5645"
+    ca5257e = "form1"
 
 
 class CanadaFillna(Enum):
@@ -217,29 +238,29 @@ class CanadaFillna(Enum):
     """
 
     # 5257e
-    CountryCode_5257e = 'Unknown'
-    VisaType_5257e = 'OTHER'
-    PlaceBirthCity_5257e = 'OTHER'
-    Country_5257e = 'IRAN'
-    Citizenship_5257e = 'IRAN'
+    CountryCode_5257e = "Unknown"
+    VisaType_5257e = "OTHER"
+    PlaceBirthCity_5257e = "OTHER"
+    Country_5257e = "IRAN"
+    Citizenship_5257e = "IRAN"
     ResidencyStatus_5257e = 6
     OtherDescriptionIndicator_5257e = False
-    PreviousCountry_5257e = 'OTHER'
-    CountryWhereApplying_5257e = 'OTHER'
-    MarriageType_5257e = 'OTHER'
-    PassportCountry_5257e = 'OTHER'
-    NativeLang_5257e = 'IRAN'
-    LanguagesAbleToCommunicate_5257e = 'NEITHER'
-    IDCountry_5257e = 'IRAN'
+    PreviousCountry_5257e = "OTHER"
+    CountryWhereApplying_5257e = "OTHER"
+    MarriageType_5257e = "OTHER"
+    PassportCountry_5257e = "OTHER"
+    NativeLang_5257e = "IRAN"
+    LanguagesAbleToCommunicate_5257e = "NEITHER"
+    IDCountry_5257e = "IRAN"
     PurposeOfVisit_5257e = 7
-    ContactType_5257e = 'OTHER'
-    Occupation_5257e = 'OTHER'
+    ContactType_5257e = "OTHER"
+    Occupation_5257e = "OTHER"
     IndicatorField_5257e = False
 
     # 5645e
-    VisaApplicationType_5645e = '0'
+    VisaApplicationType_5645e = "0"
     ChildMarriageStatus_5645e = 9
-    ChildRelation_5645e = 'OTHER'
+    ChildRelation_5645e = "OTHER"
 
     # Visa result (manual file created by me :D)
     VisaResult = 0
@@ -273,7 +294,7 @@ class CustomNamingEnum(Enum):
         _name = super(CustomNamingEnum, self).name
         _name: str = _name.lower()
         # convert FOO_BAR to foo-bar (dataset convention)
-        _name = _name.replace('_', '-')
+        _name = _name.replace("_", "-")
         self._name_ = _name
         return self._name_
 
@@ -304,8 +325,7 @@ class CanadaMarriageStatus(CustomNamingEnum):
 
 
 class CanadaContactRelation(CustomNamingEnum):
-    """Contact relation in Canada data
-    """
+    """Contact relation in Canada data"""
 
     F1 = auto()
     F2 = auto()
@@ -316,8 +336,7 @@ class CanadaContactRelation(CustomNamingEnum):
 
 
 class CanadaResidencyStatus(CustomNamingEnum):
-    """Residency status in a country in Canada data
-    """
+    """Residency status in a country in Canada data"""
 
     CITIZEN = 1
     VISITOR = 3
@@ -325,8 +344,7 @@ class CanadaResidencyStatus(CustomNamingEnum):
 
 
 class Sex(CustomNamingEnum):
-    """Sex types in general
-    """
+    """Sex types in general"""
 
     FEMALE = auto()
     MALE = auto()
@@ -340,6 +358,6 @@ class Sex(CustomNamingEnum):
         return self._name_
 
 
-T0 = '19000202T000000'
+T0 = "19000202T000000"
 """a default meaningless time to fill the `None`s
 """

--- a/cvfe/data/pdf.py
+++ b/cvfe/data/pdf.py
@@ -1,17 +1,14 @@
-__all__ = [
-    'PDFIO', 'XFAPDF', 'CanadaXFA'
-]
+__all__ = ["PDFIO", "XFAPDF", "CanadaXFA"]
 
-# core
-import xml.etree.ElementTree as et
-import pypdf
 import re
-# ours: data
-from cvfe.data import functional
-from cvfe.data.constant import DocTypes
-# helpers
+import xml.etree.ElementTree as et
 from enum import Enum
 from typing import Any
+
+import pypdf
+
+from cvfe.data import functional
+from cvfe.data.constant import DocTypes
 
 
 class PDFIO:
@@ -62,9 +59,7 @@ class PDFIO:
 
 
 class XFAPDF(PDFIO):
-    """Contains functions and utility tools for dealing with XFA PDF documents.
-
-    """
+    """Contains functions and utility tools for dealing with XFA PDF documents."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -84,11 +79,11 @@ class XFAPDF(PDFIO):
             str: XFA object of the pdf file in XML format
         """
 
-        pdf_object = open(pdf_path, 'rb')
+        pdf_object = open(pdf_path, "rb")
         pdf = pypdf.PdfReader(stream=pdf_object, strict=True)
-        xfa = self.find_in_dict('/XFA', pdf.resolved_objects)
+        xfa = self.find_in_dict("/XFA", pdf.resolved_objects)
         # `datasets` keyword contains filled forms in XFA array
-        xml = xfa[xfa.index('datasets')+1].get_object().get_data()
+        xml = xfa[xfa.index("datasets") + 1].get_object().get_data()
         xml = str(xml)  # convert bytes to str
         return xml
 
@@ -117,7 +112,7 @@ class XFAPDF(PDFIO):
 
         ref: https://stackoverflow.com/questions/38852822/how-to-flatten-xml-file-in-python
         args:
-            d: A dictionary  
+            d: A dictionary
             return: An ordered dict
         """
 
@@ -163,9 +158,7 @@ class XFAPDF(PDFIO):
 
 
 class CanadaXFA(XFAPDF):
-    """Handles Canada XFA PDF files
-
-    """
+    """Handles Canada XFA PDF files"""
 
     def __init__(self) -> None:
         super().__init__()
@@ -183,26 +176,25 @@ class CanadaXFA(XFAPDF):
         """
         if type == DocTypes.canada_5257e:
             # remove bad characters
-            xml = re.sub(r"b'\\n", '', xml)
-            xml = re.sub(r"'", '', xml)
-            xml = re.sub(r"\\n", '', xml)
+            xml = re.sub(r"b'\\n", "", xml)
+            xml = re.sub(r"'", "", xml)
+            xml = re.sub(r"\\n", "", xml)
 
             # remove 9000 lines of redundant info for '5257e' doc
             tree = et.ElementTree(et.fromstring(xml))
             root = tree.getroot()
-            junk = tree.findall('LOVFile')
+            junk = tree.findall("LOVFile")
             root.remove(junk[0])
-            xml = str(et.tostring(root, encoding='utf8', method='xml'))
+            xml = str(et.tostring(root, encoding="utf8", method="xml"))
             # parsing through ElementTree adds bad characters too
-            xml = re.sub(
-                r"b'<\?xml version=\\'1.0\\' encoding=\\'utf8\\'\?>", '', xml)
-            xml = re.sub(r"'", '', xml)
-            xml = re.sub(r"\\n[ ]*", '', xml)
+            xml = re.sub(r"b'<\?xml version=\\'1.0\\' encoding=\\'utf8\\'\?>", "", xml)
+            xml = re.sub(r"'", "", xml)
+            xml = re.sub(r"\\n[ ]*", "", xml)
 
         elif type == DocTypes.canada_5645e:
             # remove bad characters
-            xml = re.sub(r"b'\\n", '', xml)
-            xml = re.sub(r"'", '', xml)
-            xml = re.sub(r"\\n", '', xml)
+            xml = re.sub(r"b'\\n", "", xml)
+            xml = re.sub(r"'", "", xml)
+            xml = re.sub(r"\\n", "", xml)
 
         return xml

--- a/cvfe/data/preprocessor.py
+++ b/cvfe/data/preprocessor.py
@@ -1,31 +1,33 @@
 __all__ = [
-    'DataframePreprocessor', 'CanadaDataframePreprocessor', 'UnitConverter',
-    'FinancialUnitConverter', 'T0', 'FileTransformCompose', 'FileTransform', 'CopyFile',
-    'MakeContentCopyProtectedMachineReadable', 'EducationCountryScoreDataframePreprocessor',
-    'EconomyCountryScoreDataframePreprocessor', 'WorldBankXMLProcessor',
-    'WorldBankDataframeProcessor',
+    "DataframePreprocessor",
+    "CanadaDataframePreprocessor",
+    "UnitConverter",
+    "FinancialUnitConverter",
+    "T0",
+    "FileTransformCompose",
+    "FileTransform",
+    "CopyFile",
+    "MakeContentCopyProtectedMachineReadable",
+    "EducationCountryScoreDataframePreprocessor",
+    "EconomyCountryScoreDataframePreprocessor",
+    "WorldBankXMLProcessor",
+    "WorldBankDataframeProcessor",
 ]
 
-# core
-from dateutil.relativedelta import *
-from dateutil import parser
-import pandas as pd
+import logging
+import shutil
+from typing import Any, Callable, Optional, Tuple, Union
+
 import numpy as np
+import pandas as pd
 import pikepdf
-# ours: data
-from cvfe.data.pdf import CanadaXFA
+from dateutil import parser
+from dateutil.relativedelta import *
+
+from cvfe.configs import CANADA_COUNTRY_CODE_TO_NAME
 from cvfe.data import functional
 from cvfe.data.constant import *
-from cvfe.configs import CANADA_COUNTRY_CODE_TO_NAME
-# helpers
-from typing import (
-    Callable,
-    Optional,
-    Tuple,
-    Union,
-    Any)
-import shutil
-import logging
+from cvfe.data.pdf import CanadaXFA
 
 # config logger
 logger = logging.getLogger(__name__)
@@ -57,17 +59,16 @@ class DataframePreprocessor:
         string: str,
         exclude: str = None,
         regex: bool = False,
-        inplace: bool = True
+        inplace: bool = True,
     ) -> Union[None, pd.DataFrame]:
-        """See :func:`cvfe.data.functional.column_dropper` for more information
-        """
+        """See :func:`cvfe.data.functional.column_dropper` for more information"""
 
         return functional.column_dropper(
             dataframe=self.dataframe,
             string=string,
             exclude=exclude,
             regex=regex,
-            inplace=inplace
+            inplace=inplace,
         )
 
     def fillna_datetime(
@@ -76,10 +77,9 @@ class DataframePreprocessor:
         type: DocTypes,
         one_sided: Union[str, bool],
         date: str = None,
-        inplace: bool = False
+        inplace: bool = False,
     ) -> Union[None, pd.DataFrame]:
-        """See :func:`cvfe.data.functional.fillna_datetime` for more details
-        """
+        """See :func:`cvfe.data.functional.fillna_datetime` for more details"""
         if date is None:
             date = T0
 
@@ -89,7 +89,7 @@ class DataframePreprocessor:
             one_sided=one_sided,
             date=date,
             inplace=inplace,
-            type=type
+            type=type,
         )
 
     def aggregate_datetime(
@@ -100,10 +100,9 @@ class DataframePreprocessor:
         if_nan: Union[str, Callable, None] = None,
         one_sided: str = None,
         reference_date: str = None,
-        current_date: str = None
+        current_date: str = None,
     ) -> pd.DataFrame:
-        """See :func:`cvfe.data.functional.aggregate_datetime` for more details
-        """
+        """See :func:`cvfe.data.functional.aggregate_datetime` for more details"""
         return functional.aggregate_datetime(
             dataframe=self.dataframe,
             col_base_name=col_base_name,
@@ -112,25 +111,21 @@ class DataframePreprocessor:
             if_nan=if_nan,
             type=type,
             reference_date=reference_date,
-            current_date=current_date
+            current_date=current_date,
         )
 
-    def file_specific_basic_transform(
-        self,
-        type: DocTypes,
-        path: str
-    ) -> pd.DataFrame:
+    def file_specific_basic_transform(self, type: DocTypes, path: str) -> pd.DataFrame:
         """
         Takes a specific file then does data type fixing, missing value filling, descretization, etc.
 
-        Note: 
+        Note:
             Since each files has its own unique tags and requirements,
             it is expected that all these transformation being hardcoded for each file,
             hence this method exists to just improve readability without any generalization
             to other problems or even files.
 
         args:
-            type: The input document type (see :class:`DocTypes <cvfe.data.constant.DocTypes>`)  
+            type: The input document type (see :class:`DocTypes <cvfe.data.constant.DocTypes>`)
         """
 
         raise NotImplementedError
@@ -139,18 +134,17 @@ class DataframePreprocessor:
         self,
         col_name: str,
         dtype: Callable,
-        if_nan: Union[str, Callable] = 'skip',
-        **kwargs
+        if_nan: Union[str, Callable] = "skip",
+        **kwargs,
     ):
-        """See :func:`cvfe.data.functional.change_dtype` for more details
-        """
+        """See :func:`cvfe.data.functional.change_dtype` for more details"""
 
         return functional.change_dtype(
             dataframe=self.dataframe,
             col_name=col_name,
             dtype=dtype,
             if_nan=if_nan,
-            **kwargs
+            **kwargs,
         )
 
     def config_csv_to_dict(self, path: str) -> dict:
@@ -162,7 +156,9 @@ class DataframePreprocessor:
         """
 
         config_df = pd.read_csv(path)
-        return dict(zip(config_df[config_df.columns[0]], config_df[config_df.columns[1]]))
+        return dict(
+            zip(config_df[config_df.columns[0]], config_df[config_df.columns[1]])
+        )
 
 
 class UnitConverter:
@@ -177,10 +173,7 @@ class UnitConverter:
         pass
 
     def unit_converter(
-        self,
-        sparse: Optional[float],
-        dense: Optional[float],
-        factor: float
+        self, sparse: Optional[float], dense: Optional[float], factor: float
     ) -> float:
         """convert ``sparse`` or ``dense`` to each other using the rule of thump of ``dense = (factor) sparse``.
 
@@ -206,11 +199,11 @@ class UnitConverter:
             sparse = factor * dense
             return sparse
         else:
-            raise ValueError('Only `sparse` or `dense` can be None.')
+            raise ValueError("Only `sparse` or `dense` can be None.")
 
 
 class WorldBankXMLProcessor:
-    """An XML processor which is customized ot handle data dumped from https://data.worldbank.org/indicator 
+    """An XML processor which is customized ot handle data dumped from https://data.worldbank.org/indicator
 
     Note:
         Since it is used by mainstream, works for us too.
@@ -242,7 +235,7 @@ class WorldBankXMLProcessor:
         Values are scaled into [1, 7] range to match other
         world bank data processors.
 
-        In this scenario, pivots a row-based dataframe to column based 
+        In this scenario, pivots a row-based dataframe to column based
         for ``'Years'`` and aggregates over them to achieve
         a 2-columns dataframe.
 
@@ -253,60 +246,63 @@ class WorldBankXMLProcessor:
         """
         dataframe = self.dataframe
         # pivot XML attributes of `<field>` tag
-        dataframe = dataframe.pivot(columns='name', values='field')
-        dataframe = dataframe.drop('Item', axis=1)
+        dataframe = dataframe.pivot(columns="name", values="field")
+        dataframe = dataframe.drop("Item", axis=1)
         # fill None s created by pivoting (onehot to stacked) only over country names
-        dataframe['Country or Area'] = dataframe['Country or Area'].ffill().bfill()
+        dataframe["Country or Area"] = dataframe["Country or Area"].ffill().bfill()
         dataframe = dataframe.drop_duplicates()  # drop repetition of onehots
         dataframe = dataframe.ffill().bfill()  # fill None of values of countries
-        dataframe = self.__include_years(
-            dataframe=dataframe)  # exclude old years
+        dataframe = self.__include_years(dataframe=dataframe)  # exclude old years
         # dataframe = dataframe[dataframe['Year'].astype(int) >= 2017]
-        dataframe = dataframe.drop_duplicates(subset=['Country or Area', 'Year'],
-                                              keep='last').reset_index()
+        dataframe = dataframe.drop_duplicates(
+            subset=["Country or Area", "Year"], keep="last"
+        ).reset_index()
         # pivot `Years` values as a set of separate columns i.e.
         #   from [name, years] -> [name, year1, year2, ...]
-        df2 = dataframe.pivot(index='index', columns='Year', values='Value')
+        df2 = dataframe.pivot(index="index", columns="Year", values="Value")
         # add names to pivoted years
-        dataframe.drop('index', axis=1, inplace=True)
+        dataframe.drop("index", axis=1, inplace=True)
         dataframe.reset_index(inplace=True)
         df2.reset_index(inplace=True)
-        dataframe = df2.join(dataframe['Country or Area'])
+        dataframe = df2.join(dataframe["Country or Area"])
         # fill None s after pivoting `Years`
-        country_names = dataframe['Country or Area'].unique()
+        country_names = dataframe["Country or Area"].unique()
         for cn in country_names:
-            dataframe[dataframe['Country or Area'] ==
-                      cn] = dataframe[dataframe['Country or Area'] == cn].ffill().bfill()
+            dataframe[dataframe["Country or Area"] == cn] = (
+                dataframe[dataframe["Country or Area"] == cn].ffill().bfill()
+            )
         # drop duplicates caused by filling None s of pivoting
-        dataframe = dataframe.drop_duplicates(subset=['Country or Area'])
+        dataframe = dataframe.drop_duplicates(subset=["Country or Area"])
 
         # aggregation
         # drop scores/ranks and aggregate them into one column
-        dataframe.drop('index', axis=1, inplace=True)
+        dataframe.drop("index", axis=1, inplace=True)
         mean_columns = [c for c in dataframe.columns.values if c.isnumeric()]
-        dataframe['mean'] = dataframe[mean_columns].astype(float).mean(axis=1)
+        dataframe["mean"] = dataframe[mean_columns].astype(float).mean(axis=1)
         dataframe.drop(dataframe.columns[:-2], axis=1, inplace=True)
 
         dataframe[dataframe.columns[0]] = dataframe[dataframe.columns[0]].apply(
-            lambda x: x.lower())
+            lambda x: x.lower()
+        )
 
         # scale to [1-7] (standard of World Data Bank)
-        column_max = dataframe['mean'].max()
-        column_min = dataframe['mean'].min()
+        column_max = dataframe["mean"].max()
+        column_min = dataframe["mean"].min()
 
         def standardize(x):
-            """Standardize the given value to [1, 7]
+            """Standardize the given value to [1, 7]"""
+            return (((x - column_min) * (7.0 - 1.0)) / (column_max - column_min)) + 1.0
 
-            """
-            return (((x - column_min) * (7. - 1.)) / (column_max - column_min)) + 1.
-        dataframe['mean'] = dataframe['mean'].apply(standardize)
-        return dict(zip(dataframe[dataframe.columns[0]], dataframe[dataframe.columns[1]]))
+        dataframe["mean"] = dataframe["mean"].apply(standardize)
+        return dict(
+            zip(dataframe[dataframe.columns[0]], dataframe[dataframe.columns[1]])
+        )
 
     @staticmethod
     def __include_years(
         dataframe: pd.DataFrame,
         start: Union[int, None] = None,
-        end: Union[int, None] = None
+        end: Union[int, None] = None,
     ) -> pd.DataFrame:
         """Drop columns to only include years given start and end.
 
@@ -328,8 +324,8 @@ class WorldBankXMLProcessor:
         """
         start = 2017 if start is None else start
 
-        assert end is None, 'Currently only supports starting date'
-        dataframe = dataframe[dataframe['Year'].astype(int) >= start]
+        assert end is None, "Currently only supports starting date"
+        dataframe = dataframe[dataframe["Year"].astype(int) >= start]
         return dataframe
 
     def convert_country_name_to_numeric(self, string: str) -> float:
@@ -352,18 +348,16 @@ class WorldBankXMLProcessor:
             float: Numerical value of the country
         """
         if string is None:
-            string = 'Unknown'
+            string = "Unknown"
         string = string.lower()
         # see `self.indicator_filter` for description of `1.` and `150` magic numbers
         return functional.search_dict(
-            string=string,
-            if_nan=1.,
-            dic=self.country_name_to_numeric_dict
+            string=string, if_nan=1.0, dic=self.country_name_to_numeric_dict
         )
 
 
 class WorldBankDataframeProcessor:
-    """A Pandas Dataframe processor which is customized to handle data dumped from WorldBank_ 
+    """A Pandas Dataframe processor which is customized to handle data dumped from WorldBank_
 
     It's recommended to extend this class to work with particular indicator by
     first filtering by a indicator_ from WorldBank_ , then manipulating
@@ -377,9 +371,7 @@ class WorldBankDataframeProcessor:
     """
 
     def __init__(
-        self,
-        dataframe: pd.DataFrame,
-        subindicator_rank: bool = False
+        self, dataframe: pd.DataFrame, subindicator_rank: bool = False
     ) -> None:
         """Drops redundant columns of of `dataframe` and prepares a column wise subset of it
 
@@ -393,20 +385,21 @@ class WorldBankDataframeProcessor:
         """
         # set constants
         self.dataframe = dataframe
-        self.INDICATOR = 'Indicator'
-        self.SUBINDICATOR = 'Subindicator Type'
+        self.INDICATOR = "Indicator"
+        self.SUBINDICATOR = "Subindicator Type"
         self.subindicator_rank = subindicator_rank
-        self.SUBINDICATOR_TYPE = 'Rank' if subindicator_rank else '1-7 Best'
+        self.SUBINDICATOR_TYPE = "Rank" if subindicator_rank else "1-7 Best"
         # drop useless columns
-        columns_to_drop = ['Country ISO3', 'Indicator Id', ]
-        columns_to_drop = columns_to_drop + \
-            [c for c in dataframe.columns.values if '-' in c]
+        columns_to_drop = [
+            "Country ISO3",
+            "Indicator Id",
+        ]
+        columns_to_drop = columns_to_drop + [
+            c for c in dataframe.columns.values if "-" in c
+        ]
         self.dataframe.drop(columns_to_drop, axis=1, inplace=True)
 
-    def include_years(
-        self,
-        years: Tuple[Optional[int], Optional[int]] = None
-    ) -> None:
+    def include_years(self, years: Tuple[Optional[int], Optional[int]] = None) -> None:
         """Processes a dataframe to only include years given tuple of ``years=(start, end)``.
 
         Works inplace, hence manipulates original dataframe.
@@ -418,18 +411,19 @@ class WorldBankDataframeProcessor:
         """
 
         # figure out start and end year index of columns names values
-        start_year, end_year = [
-            str(y) for y in years] if years is not None else (None, None)
-        column_years = [
-            c for c in self.dataframe.columns.values if c.isnumeric()]
-        start_year_index = column_years.index(
-            start_year) if start_year is not None else 0
-        end_year_index = column_years.index(
-            end_year) if end_year is not None else -1
+        start_year, end_year = (
+            [str(y) for y in years] if years is not None else (None, None)
+        )
+        column_years = [c for c in self.dataframe.columns.values if c.isnumeric()]
+        start_year_index = (
+            column_years.index(start_year) if start_year is not None else 0
+        )
+        end_year_index = column_years.index(end_year) if end_year is not None else -1
         # dataframe with desired years
-        sub_column_years = column_years[start_year_index: end_year_index+1]
-        columns_to_drop = [c for c in list(
-            set(column_years) - set(sub_column_years)) if c.isnumeric()]
+        sub_column_years = column_years[start_year_index : end_year_index + 1]
+        columns_to_drop = [
+            c for c in list(set(column_years) - set(sub_column_years)) if c.isnumeric()
+        ]
         self.dataframe.drop(columns_to_drop, axis=True, inplace=True)
 
     def indicator_filter(self, indicator_name: str) -> pd.DataFrame:
@@ -447,29 +441,30 @@ class WorldBankDataframeProcessor:
         # filter rows that only contain the provided `indicator_name` with type `rank` or `score`
         dataframe = self.dataframe.copy()
         dataframe = dataframe[
-            (dataframe[self.INDICATOR] == indicator_name) &
-            (dataframe[self.SUBINDICATOR] == self.SUBINDICATOR_TYPE)]
-        dataframe.drop(
-            [self.INDICATOR, self.SUBINDICATOR],
-            axis=1,
-            inplace=True)
+            (dataframe[self.INDICATOR] == indicator_name)
+            & (dataframe[self.SUBINDICATOR] == self.SUBINDICATOR_TYPE)
+        ]
+        dataframe.drop([self.INDICATOR, self.SUBINDICATOR], axis=1, inplace=True)
         # drop scores/ranks and aggregate them into one column
-        dataframe[indicator_name + '_mean'] = dataframe.mean(
-            axis=1,
-            skipna=True,
-            numeric_only=True)
+        dataframe[indicator_name + "_mean"] = dataframe.mean(
+            axis=1, skipna=True, numeric_only=True
+        )
         dataframe.drop(dataframe.columns[1:-1], axis=1, inplace=True)
 
         # add a default row when input country name is 'Unknown` (this value was hardcoded in XFA PDF LOV field)
         df_unknown = pd.DataFrame(
-            {dataframe.columns[0]: ['Unknown'], dataframe.columns[1]: [None]})
+            {dataframe.columns[0]: ["Unknown"], dataframe.columns[1]: [None]}
+        )
         dataframe = pd.concat(
-            objs=[dataframe, df_unknown], axis=0,
-            verify_integrity=True, ignore_index=True)
+            objs=[dataframe, df_unknown],
+            axis=0,
+            verify_integrity=True,
+            ignore_index=True,
+        )
 
         # fillna since there is no info in the past years of that country -> unknown country
         if not self.subindicator_rank:  # fillna with lowest score = 1.
-            dataframe = dataframe.fillna(value=1.)
+            dataframe = dataframe.fillna(value=1.0)
         else:  # fillna with highest rank = 150
             dataframe = dataframe.fillna(value=150)
         return dataframe
@@ -482,28 +477,27 @@ class EducationCountryScoreDataframePreprocessor(WorldBankDataframeProcessor):
     """
 
     def __init__(
-        self,
-        dataframe: pd.DataFrame,
-        subindicator_rank: bool = False
+        self, dataframe: pd.DataFrame, subindicator_rank: bool = False
     ) -> None:
-        """See :class:`WorldBankDataframeProcessor` for more details.
-
-        """
+        """See :class:`WorldBankDataframeProcessor` for more details."""
         super().__init__(dataframe, subindicator_rank)
 
-        self.INDICATOR_NAME = 'Quality of the education system, 1-7 (best)'
+        self.INDICATOR_NAME = "Quality of the education system, 1-7 (best)"
         self.country_name_to_numeric_dict = self.__indicator_filter()
 
     def __indicator_filter(self) -> dict:
         """Filters the rows by a constant ``INDICATOR_NAME``
 
-        Returns: 
+        Returns:
             dict: A dictionary of ``country_name: score`` pairs.
         """
         dataframe = self.indicator_filter(indicator_name=self.INDICATOR_NAME)
         dataframe[dataframe.columns[0]] = dataframe[dataframe.columns[0]].apply(
-            lambda x: x.lower())
-        return dict(zip(dataframe[dataframe.columns[0]], dataframe[dataframe.columns[1]]))
+            lambda x: x.lower()
+        )
+        return dict(
+            zip(dataframe[dataframe.columns[0]], dataframe[dataframe.columns[1]])
+        )
 
     def convert_country_name_to_numeric(self, string: str) -> float:
         """Converts the name of a country into a numerical value
@@ -527,13 +521,13 @@ class EducationCountryScoreDataframePreprocessor(WorldBankDataframeProcessor):
         """
 
         if string is None:
-            string = 'Unknown'
+            string = "Unknown"
         string = string.lower()
         # see `self.indicator_filter` for description of `1.` and `150` magic numbers
         return functional.search_dict(
             string=string,
             dic=self.country_name_to_numeric_dict,
-            if_nan=1. if not self.subindicator_rank else 150
+            if_nan=1.0 if not self.subindicator_rank else 150,
         )
 
 
@@ -543,24 +537,28 @@ class EconomyCountryScoreDataframePreprocessor(WorldBankDataframeProcessor):
     The value ranges from 1 to 7 as the score where higher is better.
     """
 
-    def __init__(self, dataframe: pd.DataFrame, subindicator_rank: bool = False) -> None:
-        """See :class:`WorldBankDataframeProcessor` for more details.
-        """
+    def __init__(
+        self, dataframe: pd.DataFrame, subindicator_rank: bool = False
+    ) -> None:
+        """See :class:`WorldBankDataframeProcessor` for more details."""
         super().__init__(dataframe, subindicator_rank)
 
-        self.INDICATOR_NAME = 'Global Competitiveness Index'
+        self.INDICATOR_NAME = "Global Competitiveness Index"
         self.country_name_to_numeric_dict = self.__indicator_filter()
 
     def __indicator_filter(self) -> dict:
         """Filters the rows by a constant ``INDICATOR_NAME``
 
-        Returns: 
+        Returns:
             dict: A dictionary of ``country_name: score`` pairs.
         """
         dataframe = self.indicator_filter(indicator_name=self.INDICATOR_NAME)
         dataframe[dataframe.columns[0]] = dataframe[dataframe.columns[0]].apply(
-            lambda x: x.lower())
-        return dict(zip(dataframe[dataframe.columns[0]], dataframe[dataframe.columns[1]]))
+            lambda x: x.lower()
+        )
+        return dict(
+            zip(dataframe[dataframe.columns[0]], dataframe[dataframe.columns[1]])
+        )
 
     def convert_country_name_to_numeric(self, string: str) -> float:
         """Converts the name of a country into a numerical value
@@ -583,25 +581,26 @@ class EconomyCountryScoreDataframePreprocessor(WorldBankDataframeProcessor):
             float: Numerical value of the country
         """
         if string is None:
-            string = 'Unknown'
+            string = "Unknown"
         string = string.lower()
         # see `self.indicator_filter` for description of `1.` and `150` magic numbers
         return functional.search_dict(
             string=string,
             dic=self.country_name_to_numeric_dict,
-            if_nan=1. if not self.subindicator_rank else 150
+            if_nan=1.0 if not self.subindicator_rank else 150,
         )
 
 
 class CanadaDataframePreprocessor(DataframePreprocessor):
     def __init__(self, dataframe: pd.DataFrame = None) -> None:
         super().__init__(dataframe)
-        self.base_date = None  # the time forms were filled, considered "today" for forms
+        self.base_date = (
+            None  # the time forms were filled, considered "today" for forms
+        )
 
         # get country code to name dict
         self.config_path = CANADA_COUNTRY_CODE_TO_NAME
-        self.CANADA_COUNTRY_CODE_TO_NAME = self.config_csv_to_dict(
-            self.config_path)
+        self.CANADA_COUNTRY_CODE_TO_NAME = self.config_csv_to_dict(self.config_path)
 
     def convert_country_code_to_name(self, string: str) -> str:
         """
@@ -611,14 +610,16 @@ class CanadaDataframePreprocessor(DataframePreprocessor):
             string: input code string
         """
 
-        country = [c for c in self.CANADA_COUNTRY_CODE_TO_NAME.keys()
-                   if string in c]
+        country = [c for c in self.CANADA_COUNTRY_CODE_TO_NAME.keys() if string in c]
         if country:
             return self.CANADA_COUNTRY_CODE_TO_NAME[country]
         else:
             logger.debug(
-                (f'"{string}" country code could not be found'
-                f'in the config file="{self.config_path}".'))
+                (
+                    f'"{string}" country code could not be found'
+                    f'in the config file="{self.config_path}".'
+                )
+            )
             return CanadaFillna.CountryCode_5257e.value
 
     def file_specific_basic_transform(self, type: DocTypes, path: str) -> pd.DataFrame:
@@ -627,8 +628,7 @@ class CanadaDataframePreprocessor(DataframePreprocessor):
         if type == DocTypes.canada_5257e:
             # XFA to XML
             xml = canada_xfa.extract_raw_content(path)
-            xml = canada_xfa.clean_xml_for_csv(
-                xml=xml, type=DocTypes.canada_5257e)
+            xml = canada_xfa.clean_xml_for_csv(xml=xml, type=DocTypes.canada_5257e)
             # XML to flattened dict
             data_dict = canada_xfa.xml_to_flattened_dict(xml=xml)
             data_dict = canada_xfa.flatten_dict(data_dict)
@@ -637,427 +637,441 @@ class CanadaDataframePreprocessor(DataframePreprocessor):
                 data_dict,
                 cutoff_term=CanadaCutoffTerms.ca5257e.value,
                 KEY_ABBREVIATION_DICT=CANADA_5257E_KEY_ABBREVIATION,
-                VALUE_ABBREVIATION_DICT=CANADA_5257E_VALUE_ABBREVIATION
+                VALUE_ABBREVIATION_DICT=CANADA_5257E_VALUE_ABBREVIATION,
             )
             # convert each data dict to a dataframe
-            dataframe = pd.DataFrame.from_dict(
-                data=[data_dict],
-                orient='columns'
-            )
+            dataframe = pd.DataFrame.from_dict(data=[data_dict], orient="columns")
             self.dataframe = dataframe
             # drop pepeg columns
             #   warning: setting `errors='ignore` ignores errors if columns do not exist!
             dataframe.drop(
-                CANADA_5257E_DROP_COLUMNS,
-                axis=1,
-                inplace=True,
-                errors='ignore'
+                CANADA_5257E_DROP_COLUMNS, axis=1, inplace=True, errors="ignore"
             )
 
             # Adult binary state: adult=True or child=False
-            dataframe['P1.AdultFlag'] = dataframe['P1.AdultFlag'].apply(
-                lambda x: True if x == 'adult' else False
+            dataframe["P1.AdultFlag"] = dataframe["P1.AdultFlag"].apply(
+                lambda x: True if x == "adult" else False
             )
             # service language: 1=En, 2=Fr -> need to be changed to categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.ServiceIn.ServiceIn',
-                dtype=np.int8,
-                if_nan='skip'
+                col_name="P1.PD.ServiceIn.ServiceIn", dtype=np.int8, if_nan="skip"
             )
             # AliasNameIndicator: 1=True, 0=False
-            dataframe['P1.PD.AliasName.AliasNameIndicator.AliasNameIndicator'] = dataframe['P1.PD.AliasName.AliasNameIndicator.AliasNameIndicator'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe[
+                "P1.PD.AliasName.AliasNameIndicator.AliasNameIndicator"
+            ] = dataframe[
+                "P1.PD.AliasName.AliasNameIndicator.AliasNameIndicator"
+            ].apply(
+                lambda x: True if x == "Y" else False
+            )
             # VisaType: String -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.VisaType.VisaType',
+                col_name="P1.PD.VisaType.VisaType",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.VisaType_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.VisaType_5257e.value,
             )
             # Birth City: String -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.PlaceBirthCity',
+                col_name="P1.PD.PlaceBirthCity",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.PlaceBirthCity_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.PlaceBirthCity_5257e.value,
             )
             # Birth country: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.PlaceBirthCountry',
+                col_name="P1.PD.PlaceBirthCountry",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.Country_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.Country_5257e.value,
             )
             # citizen of: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.Citizenship.Citizenship',
+                col_name="P1.PD.Citizenship.Citizenship",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.Citizenship_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.Citizenship_5257e.value,
             )
             # current country of residency: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.CurrCOR.Row2.Country',
+                col_name="P1.PD.CurrCOR.Row2.Country",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.Country_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.Country_5257e.value,
             )
             # current country of residency status: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.CurrCOR.Row2.Status',
+                col_name="P1.PD.CurrCOR.Row2.Status",
                 dtype=np.int8,
-                if_nan='fill',
-                value=np.int8(CanadaFillna.ResidencyStatus_5257e.value)
+                if_nan="fill",
+                value=np.int8(CanadaFillna.ResidencyStatus_5257e.value),
             )
             # current country of residency other description: bool -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.CurrCOR.Row2.Other',
+                col_name="P1.PD.CurrCOR.Row2.Other",
                 dtype=bool,
-                if_nan='fill',
-                value=CanadaFillna.OtherDescriptionIndicator_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.OtherDescriptionIndicator_5257e.value,
             )
             # validation date of information, i.e. current date: datetime
             dataframe = self.change_dtype(
-                col_name='P3.Sign.C1CertificateIssueDate',
+                col_name="P3.Sign.C1CertificateIssueDate",
                 dtype=parser.parse,
-                if_nan='skip'
+                if_nan="skip",
             )
             # keep it so we can access for other file if that was None
-            if not dataframe['P3.Sign.C1CertificateIssueDate'].isna().all():
-                self.base_date = dataframe['P3.Sign.C1CertificateIssueDate']
+            if not dataframe["P3.Sign.C1CertificateIssueDate"].isna().all():
+                self.base_date = dataframe["P3.Sign.C1CertificateIssueDate"]
             # date of birth in year: string -> datetime
             dataframe = self.change_dtype(
-                col_name='P1.PD.DOBYear',
-                dtype=parser.parse,
-                if_nan='skip'
+                col_name="P1.PD.DOBYear", dtype=parser.parse, if_nan="skip"
             )
             # current country of residency period: None -> Datetime (=age period)
             dataframe = self.change_dtype(
-                col_name='P1.PD.CurrCOR.Row2.FromDate',
+                col_name="P1.PD.CurrCOR.Row2.FromDate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P1.PD.DOBYear']
+                if_nan="fill",
+                value=dataframe["P1.PD.DOBYear"],
             )
             dataframe = self.change_dtype(
-                col_name='P1.PD.CurrCOR.Row2.ToDate',
+                col_name="P1.PD.CurrCOR.Row2.ToDate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             # has previous country of residency: bool -> categorical
-            dataframe['P1.PD.PCRIndicator'] = dataframe['P1.PD.PCRIndicator'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P1.PD.PCRIndicator"] = dataframe["P1.PD.PCRIndicator"].apply(
+                lambda x: True if x == "Y" else False
+            )
 
             # clean previous country of residency features
             country_tag_list = [
-                c for c in dataframe.columns.values if 'P1.PD.PrevCOR.' in c]
+                c for c in dataframe.columns.values if "P1.PD.PrevCOR." in c
+            ]
             PREV_COUNTRY_MAX_FEATURES = 4
             for i in range(len(country_tag_list) // PREV_COUNTRY_MAX_FEATURES):
                 # in XLA extracted file, this section start from `Row2` (ie. i+2)
                 i += 2
                 # previous country of residency 02: string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='P1.PD.PrevCOR.Row'+str(i)+'.Country',
+                    col_name="P1.PD.PrevCOR.Row" + str(i) + ".Country",
                     dtype=str,
-                    if_nan='fill',
-                    value=CanadaFillna.PreviousCountry_5257e.value
+                    if_nan="fill",
+                    value=CanadaFillna.PreviousCountry_5257e.value,
                 )
                 # previous country of residency status 02: string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='P1.PD.PrevCOR.Row'+str(i)+'.Status',
+                    col_name="P1.PD.PrevCOR.Row" + str(i) + ".Status",
                     dtype=np.int8,
-                    if_nan='fill',
-                    value=np.int8(CanadaFillna.ResidencyStatus_5257e.value)
+                    if_nan="fill",
+                    value=np.int8(CanadaFillna.ResidencyStatus_5257e.value),
                 )
                 # previous country of residency 02 period (P1.PD.PrevCOR.Row2): string -> datetime -> int days
                 dataframe = self.change_dtype(
-                    col_name='P1.PD.PrevCOR.Row'+str(i)+'.FromDate',
-                    dtype=parser.parse, if_nan='fill',
-                    value=dataframe['P3.Sign.C1CertificateIssueDate']
+                    col_name="P1.PD.PrevCOR.Row" + str(i) + ".FromDate",
+                    dtype=parser.parse,
+                    if_nan="fill",
+                    value=dataframe["P3.Sign.C1CertificateIssueDate"],
                 )
                 dataframe = self.change_dtype(
-                    col_name='P1.PD.PrevCOR.Row'+str(i)+'.ToDate',
-                    dtype=parser.parse, if_nan='fill',
-                    value=dataframe['P3.Sign.C1CertificateIssueDate']
+                    col_name="P1.PD.PrevCOR.Row" + str(i) + ".ToDate",
+                    dtype=parser.parse,
+                    if_nan="fill",
+                    value=dataframe["P3.Sign.C1CertificateIssueDate"],
                 )
             # apply from country of residency (cwa=country where apply): Y=True, N=False
-            dataframe['P1.PD.SameAsCORIndicator'] = dataframe['P1.PD.SameAsCORIndicator'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P1.PD.SameAsCORIndicator"] = dataframe[
+                "P1.PD.SameAsCORIndicator"
+            ].apply(lambda x: True if x == "Y" else False)
             # country where applying: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.CWA.Row2.Country',
+                col_name="P1.PD.CWA.Row2.Country",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.CountryWhereApplying_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.CountryWhereApplying_5257e.value,
             )
             # country where applying status: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.CWA.Row2.Status',
+                col_name="P1.PD.CWA.Row2.Status",
                 dtype=np.int8,
-                if_nan='fill',
-                value=np.int8(CanadaFillna.ResidencyStatus_5257e.value)
+                if_nan="fill",
+                value=np.int8(CanadaFillna.ResidencyStatus_5257e.value),
             )
             # country where applying other: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P1.PD.CWA.Row2.Other',
+                col_name="P1.PD.CWA.Row2.Other",
                 dtype=bool,
-                if_nan='fill',
-                value=CanadaFillna.OtherDescriptionIndicator_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.OtherDescriptionIndicator_5257e.value,
             )
             # country where applying period: datetime -> int days
             dataframe = self.change_dtype(
-                col_name='P1.PD.CWA.Row2.FromDate',
+                col_name="P1.PD.CWA.Row2.FromDate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             dataframe = self.change_dtype(
-                col_name='P1.PD.CWA.Row2.ToDate',
+                col_name="P1.PD.CWA.Row2.ToDate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             # marriage period: datetime -> int days
             dataframe = self.change_dtype(
-                col_name='P1.MS.SecA.DateOfMarr',
+                col_name="P1.MS.SecA.DateOfMarr",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             # previous marriage: Y=True, N=False
-            dataframe['P2.MS.SecA.PrevMarrIndicator'] = dataframe['P2.MS.SecA.PrevMarrIndicator'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P2.MS.SecA.PrevMarrIndicator"] = dataframe[
+                "P2.MS.SecA.PrevMarrIndicator"
+            ].apply(lambda x: True if x == "Y" else False)
             # previous marriage type of relationship
             dataframe = self.change_dtype(
-                col_name='P2.MS.SecA.TypeOfRelationship',
+                col_name="P2.MS.SecA.TypeOfRelationship",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.MarriageType_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.MarriageType_5257e.value,
             )
             # previous spouse age period: string -> datetime -> int days
             dataframe = self.change_dtype(
-                col_name='P2.MS.SecA.PrevSpouseDOB.DOBYear',
+                col_name="P2.MS.SecA.PrevSpouseDOB.DOBYear",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             # previous marriage period: string -> datetime -> int days
             dataframe = self.change_dtype(
-                col_name='P2.MS.SecA.FromDate',
+                col_name="P2.MS.SecA.FromDate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             dataframe = self.change_dtype(
-                col_name='P2.MS.SecA.ToDate.ToDate',
+                col_name="P2.MS.SecA.ToDate.ToDate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             # passport country of issue: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P2.MS.SecA.Psprt.CountryofIssue.CountryofIssue',
+                col_name="P2.MS.SecA.Psprt.CountryofIssue.CountryofIssue",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.PassportCountry_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.PassportCountry_5257e.value,
             )
             # expiry remaining period: datetime -> int days
             # if None, fill with 1 year ago, ie. period=1year
-            temp_date = dataframe['P3.Sign.C1CertificateIssueDate'].apply(
-                lambda x: x+relativedelta(years=-1))
+            temp_date = dataframe["P3.Sign.C1CertificateIssueDate"].apply(
+                lambda x: x + relativedelta(years=-1)
+            )
             dataframe = self.change_dtype(
-                col_name='P2.MS.SecA.Psprt.ExpiryDate',
+                col_name="P2.MS.SecA.Psprt.ExpiryDate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=temp_date
+                if_nan="fill",
+                value=temp_date,
             )
             # native lang: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P2.MS.SecA.Langs.languages.nativeLang.nativeLang',
+                col_name="P2.MS.SecA.Langs.languages.nativeLang.nativeLang",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.NativeLang_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.NativeLang_5257e.value,
             )
             # communication lang: Eng, Fr, both, none -> categorical
             dataframe = self.change_dtype(
-                col_name='P2.MS.SecA.Langs.languages.ableToCommunicate.ableToCommunicate',
+                col_name="P2.MS.SecA.Langs.languages.ableToCommunicate.ableToCommunicate",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.LanguagesAbleToCommunicate_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.LanguagesAbleToCommunicate_5257e.value,
             )
             # language official test: bool -> binary
-            dataframe['P2.MS.SecA.Langs.LangTest'] = dataframe['P2.MS.SecA.Langs.LangTest'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P2.MS.SecA.Langs.LangTest"] = dataframe[
+                "P2.MS.SecA.Langs.LangTest"
+            ].apply(lambda x: True if x == "Y" else False)
             # have national ID: bool -> binary
-            dataframe['P2.natID.q1.natIDIndicator'] = dataframe['P2.natID.q1.natIDIndicator'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P2.natID.q1.natIDIndicator"] = dataframe[
+                "P2.natID.q1.natIDIndicator"
+            ].apply(lambda x: True if x == "Y" else False)
             # national ID country of issue: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P2.natID.natIDdocs.CountryofIssue.CountryofIssue',
+                col_name="P2.natID.natIDdocs.CountryofIssue.CountryofIssue",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.IDCountry_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.IDCountry_5257e.value,
             )
             # United States doc: bool -> binary
-            dataframe['P2.USCard.q1.usCardIndicator'] = dataframe['P2.USCard.q1.usCardIndicator'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P2.USCard.q1.usCardIndicator"] = dataframe[
+                "P2.USCard.q1.usCardIndicator"
+            ].apply(lambda x: True if x == "Y" else False)
             # US Canada phone number: bool -> binary
-            dataframe['P2.CI.cntct.PhnNums.Phn.CanadaUS'] = dataframe['P2.CI.cntct.PhnNums.Phn.CanadaUS'].apply(
-                lambda x: True if x == '1' else False)
+            dataframe["P2.CI.cntct.PhnNums.Phn.CanadaUS"] = dataframe[
+                "P2.CI.cntct.PhnNums.Phn.CanadaUS"
+            ].apply(lambda x: True if x == "1" else False)
             # US Canada alt phone number: bool -> binary
-            dataframe['P2.CI.cntct.PhnNums.AltPhn.CanadaUS'] = dataframe['P2.CI.cntct.PhnNums.AltPhn.CanadaUS'].apply(
-                lambda x: True if x == '1' else False)
+            dataframe["P2.CI.cntct.PhnNums.AltPhn.CanadaUS"] = dataframe[
+                "P2.CI.cntct.PhnNums.AltPhn.CanadaUS"
+            ].apply(lambda x: True if x == "1" else False)
             # purpose of visit: string, 8 states -> categorical
             dataframe = self.change_dtype(
-                col_name='P3.DOV.PrpsRow1.PrpsOfVisit.PrpsOfVisit',
+                col_name="P3.DOV.PrpsRow1.PrpsOfVisit.PrpsOfVisit",
                 dtype=np.int8,
-                if_nan='fill',
-                value=np.int8(CanadaFillna.PurposeOfVisit_5257e.value)
+                if_nan="fill",
+                value=np.int8(CanadaFillna.PurposeOfVisit_5257e.value),
             )  # 7 is other in the form
             # purpose of visit description: string -> binary
             dataframe = self.change_dtype(
-                col_name='P3.DOV.PrpsRow1.Other.Other',
+                col_name="P3.DOV.PrpsRow1.Other.Other",
                 dtype=bool,
-                if_nan='fill',
-                value=CanadaFillna.OtherDescriptionIndicator_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.OtherDescriptionIndicator_5257e.value,
             )
             # how long going to stay: None -> datetime (0 days)
             dataframe = self.change_dtype(
-                col_name='P3.DOV.PrpsRow1.HLS.FromDate',
+                col_name="P3.DOV.PrpsRow1.HLS.FromDate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             dataframe = self.change_dtype(
-                col_name='P3.DOV.PrpsRow1.HLS.ToDate',
+                col_name="P3.DOV.PrpsRow1.HLS.ToDate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             # fund to integer
             dataframe = self.change_dtype(
-                col_name='P3.DOV.PrpsRow1.Funds.Funds',
-                dtype=np.int32,
-                if_nan='skip'
+                col_name="P3.DOV.PrpsRow1.Funds.Funds", dtype=np.int32, if_nan="skip"
             )
             # relation to applicant of purpose of visit 01: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P3.DOV.cntcts_Row1.RelationshipToMe.RelationshipToMe',
+                col_name="P3.DOV.cntcts_Row1.RelationshipToMe.RelationshipToMe",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.ContactType_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.ContactType_5257e.value,
             )
             # relation to applicant of purpose of visit 02: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P3.cntcts_Row2.Relationship.RelationshipToMe',
+                col_name="P3.cntcts_Row2.Relationship.RelationshipToMe",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.ContactType_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.ContactType_5257e.value,
             )
             # higher education: bool -> binary
-            dataframe['P3.Edu.EduIndicator'] = dataframe['P3.Edu.EduIndicator'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P3.Edu.EduIndicator"] = dataframe["P3.Edu.EduIndicator"].apply(
+                lambda x: True if x == "Y" else False
+            )
             # higher education period: string -> datetime -> int days
             dataframe = self.change_dtype(
-                col_name='P3.Edu.Edu_Row1.FromYear',
+                col_name="P3.Edu.Edu_Row1.FromYear",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             dataframe = self.change_dtype(
-                col_name='P3.Edu.Edu_Row1.ToYear',
+                col_name="P3.Edu.Edu_Row1.ToYear",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['P3.Sign.C1CertificateIssueDate']
+                if_nan="fill",
+                value=dataframe["P3.Sign.C1CertificateIssueDate"],
             )
             # higher education country: string -> categorical
             dataframe = self.change_dtype(
-                col_name='P3.Edu.Edu_Row1.Country.Country',
+                col_name="P3.Edu.Edu_Row1.Country.Country",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.Country_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.Country_5257e.value,
             )
             # field of study: string -> categorical
-            dataframe['P3.Edu.Edu_Row1.FieldOfStudy'] = dataframe['P3.Edu.Edu_Row1.FieldOfStudy'].astype(
-                'string')
+            dataframe["P3.Edu.Edu_Row1.FieldOfStudy"] = dataframe[
+                "P3.Edu.Edu_Row1.FieldOfStudy"
+            ].astype("string")
             # clean occupation features
             occupation_tag_list = [
-                c for c in dataframe.columns.values if 'P3.Occ.OccRow' in c]
+                c for c in dataframe.columns.values if "P3.Occ.OccRow" in c
+            ]
             PREV_OCCUPATION_MAX_FEATURES = 9
             for i in range(len(occupation_tag_list) // PREV_OCCUPATION_MAX_FEATURES):
                 i += 1  # in the form, it starts from Row1 (ie. i+1)
                 # occupation period 01: none -> string year -> int days
                 dataframe = self.change_dtype(
-                    col_name='P3.Occ.OccRow'+str(i)+'.FromYear',
+                    col_name="P3.Occ.OccRow" + str(i) + ".FromYear",
                     dtype=parser.parse,
-                    if_nan='fill',
-                    value=dataframe['P3.Sign.C1CertificateIssueDate']
+                    if_nan="fill",
+                    value=dataframe["P3.Sign.C1CertificateIssueDate"],
                 )
                 dataframe = self.change_dtype(
-                    col_name='P3.Occ.OccRow'+str(i)+'.ToYear',
+                    col_name="P3.Occ.OccRow" + str(i) + ".ToYear",
                     dtype=parser.parse,
-                    if_nan='fill',
-                    value=dataframe['P3.Sign.C1CertificateIssueDate']
+                    if_nan="fill",
+                    value=dataframe["P3.Sign.C1CertificateIssueDate"],
                 )
 
                 # occupation type 01: string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='P3.Occ.OccRow'+str(i)+'.Occ.Occ',
+                    col_name="P3.Occ.OccRow" + str(i) + ".Occ.Occ",
                     dtype=str,
-                    if_nan='fill',
-                    value=CanadaFillna.Occupation_5257e.value
+                    if_nan="fill",
+                    value=CanadaFillna.Occupation_5257e.value,
                 )
                 # occupation country: string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='P3.Occ.OccRow'+str(i)+'.Country.Country',
+                    col_name="P3.Occ.OccRow" + str(i) + ".Country.Country",
                     dtype=str,
-                    if_nan='fill',
-                    value=CanadaFillna.Country_5257e.value
+                    if_nan="fill",
+                    value=CanadaFillna.Country_5257e.value,
                 )
 
             # medical details: string -> binary
             dataframe = self.change_dtype(
-                col_name='P3.BGI.Details.MedicalDetails',
+                col_name="P3.BGI.Details.MedicalDetails",
                 dtype=bool,
-                if_nan='fill',
-                value=CanadaFillna.IndicatorField_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.IndicatorField_5257e.value,
             )
             # other than medical: string -> binary
             dataframe = self.change_dtype(
-                col_name='P3.BGI.otherThanMedic',
+                col_name="P3.BGI.otherThanMedic",
                 dtype=bool,
-                if_nan='fill',
-                value=CanadaFillna.IndicatorField_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.IndicatorField_5257e.value,
             )
             # without authentication stay, work, etc: bool -> binary
-            dataframe['P3.noAuthStay'] = dataframe['P3.noAuthStay'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P3.noAuthStay"] = dataframe["P3.noAuthStay"].apply(
+                lambda x: True if x == "Y" else False
+            )
             # deported or refused entry: bool -> binary
-            dataframe['P3.refuseDeport'] = dataframe['P3.refuseDeport'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P3.refuseDeport"] = dataframe["P3.refuseDeport"].apply(
+                lambda x: True if x == "Y" else False
+            )
             # previously applied: bool -> binary
-            dataframe['P3.BGI2.PrevApply'] = dataframe['P3.BGI2.PrevApply'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P3.BGI2.PrevApply"] = dataframe["P3.BGI2.PrevApply"].apply(
+                lambda x: True if x == "Y" else False
+            )
             # criminal record: bool -> binary
-            dataframe['P3.PWrapper.criminalRec'] = dataframe['P3.PWrapper.criminalRec'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P3.PWrapper.criminalRec"] = dataframe[
+                "P3.PWrapper.criminalRec"
+            ].apply(lambda x: True if x == "Y" else False)
             # military record: bool -> binary
-            dataframe['P3.PWrapper.Military.Choice'] = dataframe['P3.PWrapper.Military.Choice'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P3.PWrapper.Military.Choice"] = dataframe[
+                "P3.PWrapper.Military.Choice"
+            ].apply(lambda x: True if x == "Y" else False)
             # political, violent movement record: bool -> binary
-            dataframe['P3.PWrapper.politicViol'] = dataframe['P3.PWrapper.politicViol'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P3.PWrapper.politicViol"] = dataframe[
+                "P3.PWrapper.politicViol"
+            ].apply(lambda x: True if x == "Y" else False)
             # witness of ill treatment: bool -> binary
-            dataframe['P3.PWrapper.witnessIllTreat'] = dataframe['P3.PWrapper.witnessIllTreat'].apply(
-                lambda x: True if x == 'Y' else False)
+            dataframe["P3.PWrapper.witnessIllTreat"] = dataframe[
+                "P3.PWrapper.witnessIllTreat"
+            ].apply(lambda x: True if x == "Y" else False)
 
             return dataframe
 
         if type == DocTypes.canada_5645e:
             # XFA to XML
             xml = canada_xfa.extract_raw_content(path)
-            xml = canada_xfa.clean_xml_for_csv(
-                xml=xml, type=DocTypes.canada_5645e)
+            xml = canada_xfa.clean_xml_for_csv(xml=xml, type=DocTypes.canada_5645e)
             # XML to flattened dict
             data_dict = canada_xfa.xml_to_flattened_dict(xml=xml)
             data_dict = canada_xfa.flatten_dict(data_dict)
@@ -1066,257 +1080,274 @@ class CanadaDataframePreprocessor(DataframePreprocessor):
                 data_dict,
                 cutoff_term=CanadaCutoffTerms.ca5645e.value,
                 KEY_ABBREVIATION_DICT=CANADA_5645E_KEY_ABBREVIATION,
-                VALUE_ABBREVIATION_DICT=None
+                VALUE_ABBREVIATION_DICT=None,
             )
 
             # convert each data dict to a dataframe
-            dataframe = pd.DataFrame.from_dict(
-                data=[data_dict],
-                orient='columns'
-            )
+            dataframe = pd.DataFrame.from_dict(data=[data_dict], orient="columns")
             self.dataframe = dataframe
 
             # drop pepeg columns
             #   warning: setting `errors='ignore` ignores errors if columns do not exist!
             dataframe.drop(
-                CANADA_5645E_DROP_COLUMNS,
-                axis=1,
-                inplace=True,
-                errors='ignore'
+                CANADA_5645E_DROP_COLUMNS, axis=1, inplace=True, errors="ignore"
             )
 
             # transform multiple pleb columns into a single chad one and fixing column dtypes
             # type of application: (already onehot) string -> int
-            cols = [col for col in dataframe.columns.values if 'p1.Subform1' in col]
+            cols = [col for col in dataframe.columns.values if "p1.Subform1" in col]
             for c in cols:
                 dataframe = self.change_dtype(
                     col_name=c,
                     dtype=np.int16,
-                    if_nan='fill',
-                    value=np.int16(CanadaFillna.VisaApplicationType_5645e.value)
+                    if_nan="fill",
+                    value=np.int16(CanadaFillna.VisaApplicationType_5645e.value),
                 )
             # drop all Accompany=No and only rely on Accompany=Yes using binary state
-            self.column_dropper(string='No', inplace=True)
+            self.column_dropper(string="No", inplace=True)
             # applicant marriage status: string to integer
             dataframe = self.change_dtype(
-                col_name='p1.SecA.App.ChdMStatus',
+                col_name="p1.SecA.App.ChdMStatus",
                 dtype=np.int16,
-                if_nan='fill',
-                value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value)
+                if_nan="fill",
+                value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value),
             )
             # validation date of information, i.e. current date: datetime
             dataframe = self.change_dtype(
-                col_name='p1.SecC.SecCdate',
+                col_name="p1.SecC.SecCdate",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=self.base_date
+                if_nan="fill",
+                value=self.base_date,
             )
             # spouse date of birth: string -> datetime
             dataframe = self.change_dtype(
-                col_name='p1.SecA.Sps.SpsDOB',
+                col_name="p1.SecA.Sps.SpsDOB",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['p1.SecC.SecCdate']
+                if_nan="fill",
+                value=dataframe["p1.SecC.SecCdate"],
             )
-            
+
             # spouse country of birth: string -> categorical
             dataframe = self.change_dtype(
-                col_name='p1.SecA.Sps.SpsCOB',
-                dtype=str,
-                if_nan='skip'
+                col_name="p1.SecA.Sps.SpsCOB", dtype=str, if_nan="skip"
             )
             # spouse occupation type (issue #2): string -> categorical
             dataframe = self.change_dtype(
-                col_name='p1.SecA.Sps.SpsOcc',
+                col_name="p1.SecA.Sps.SpsOcc",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.Occupation_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.Occupation_5257e.value,
             )
             # spouse accompanying: coming=True or not_coming=False
-            dataframe['p1.SecA.Sps.SpsAccomp'] = dataframe['p1.SecA.Sps.SpsAccomp'].apply(
-                lambda x: True if x == '1' else False)
+            dataframe["p1.SecA.Sps.SpsAccomp"] = dataframe[
+                "p1.SecA.Sps.SpsAccomp"
+            ].apply(lambda x: True if x == "1" else False)
             # mother date of birth: string -> datetime
             dataframe = self.change_dtype(
-                col_name='p1.SecA.Mo.MoDOB',
+                col_name="p1.SecA.Mo.MoDOB",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['p1.SecC.SecCdate']
+                if_nan="fill",
+                value=dataframe["p1.SecC.SecCdate"],
             )
-            
+
             # mother occupation type (issue #2): string -> categorical
             dataframe = self.change_dtype(
-                col_name='p1.SecA.Mo.MoOcc',
+                col_name="p1.SecA.Mo.MoOcc",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.Occupation_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.Occupation_5257e.value,
             )
             # mother marriage status: int -> categorical
             dataframe = self.change_dtype(
-                col_name='p1.SecA.Mo.ChdMStatus',
+                col_name="p1.SecA.Mo.ChdMStatus",
                 dtype=np.int16,
-                if_nan='fill',
-                value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value)
+                if_nan="fill",
+                value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value),
             )
             # mother accompanying: coming=True or not_coming=False
-            dataframe['p1.SecA.Mo.MoAccomp'] = dataframe['p1.SecA.Mo.MoAccomp'].apply(
-                lambda x: True if x == '1' else False)
+            dataframe["p1.SecA.Mo.MoAccomp"] = dataframe["p1.SecA.Mo.MoAccomp"].apply(
+                lambda x: True if x == "1" else False
+            )
             # father date of birth: string -> datetime
             dataframe = self.change_dtype(
-                col_name='p1.SecA.Fa.FaDOB',
+                col_name="p1.SecA.Fa.FaDOB",
                 dtype=parser.parse,
-                if_nan='fill',
-                value=dataframe['p1.SecC.SecCdate']
+                if_nan="fill",
+                value=dataframe["p1.SecC.SecCdate"],
             )
-            
+
             # mother occupation type (issue #2): string -> categorical
             dataframe = self.change_dtype(
-                col_name='p1.SecA.Fa.FaOcc',
+                col_name="p1.SecA.Fa.FaOcc",
                 dtype=str,
-                if_nan='fill',
-                value=CanadaFillna.Occupation_5257e.value
+                if_nan="fill",
+                value=CanadaFillna.Occupation_5257e.value,
             )
             # father marriage status: int -> categorical
             dataframe = self.change_dtype(
-                col_name='p1.SecA.Fa.ChdMStatus',
+                col_name="p1.SecA.Fa.ChdMStatus",
                 dtype=np.int16,
-                if_nan='fill',
-                value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value)
+                if_nan="fill",
+                value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value),
             )
             # father accompanying: coming=True or not_coming=False
-            dataframe['p1.SecA.Fa.FaAccomp'] = dataframe['p1.SecA.Fa.FaAccomp'].apply(
-                lambda x: True if x == '1' else False)
+            dataframe["p1.SecA.Fa.FaAccomp"] = dataframe["p1.SecA.Fa.FaAccomp"].apply(
+                lambda x: True if x == "1" else False
+            )
 
             # children's status
             children_tag_list = [
-                c for c in dataframe.columns.values if 'p1.SecB.Chd' in c]
+                c for c in dataframe.columns.values if "p1.SecB.Chd" in c
+            ]
             CHILDREN_MAX_FEATURES = 7
             for i in range(len(children_tag_list) // CHILDREN_MAX_FEATURES):
                 # child's marriage status 01: string to integer
                 dataframe = self.change_dtype(
-                    col_name='p1.SecB.Chd.['+str(i)+'].ChdMStatus',
+                    col_name="p1.SecB.Chd.[" + str(i) + "].ChdMStatus",
                     dtype=np.int16,
-                    if_nan='fill',
-                    value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value)
+                    if_nan="fill",
+                    value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value),
                 )
                 # child's relationship 01: string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='p1.SecB.Chd.['+str(i)+'].ChdRel',
+                    col_name="p1.SecB.Chd.[" + str(i) + "].ChdRel",
                     dtype=str,
-                    if_nan='fill',
-                    value=CanadaFillna.ChildRelation_5645e.value
+                    if_nan="fill",
+                    value=CanadaFillna.ChildRelation_5645e.value,
                 )
                 # child's date of birth 01: string -> datetime
                 dataframe = self.change_dtype(
-                    col_name='p1.SecB.Chd.['+str(i)+'].ChdDOB',
+                    col_name="p1.SecB.Chd.[" + str(i) + "].ChdDOB",
                     dtype=parser.parse,
-                    if_nan='skip'
+                    if_nan="skip",
                 )
-                
+
                 # child's country of birth 01: string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='p1.SecB.Chd.['+str(i)+'].ChdCOB',
+                    col_name="p1.SecB.Chd.[" + str(i) + "].ChdCOB",
                     dtype=str,
-                    if_nan='fill',
-                    value=CanadaFillna.Country_5257e.value
+                    if_nan="fill",
+                    value=CanadaFillna.Country_5257e.value,
                 )
                 # child's occupation type 01 (issue #2): string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='p1.SecB.Chd.['+str(i)+'].ChdOcc',
+                    col_name="p1.SecB.Chd.[" + str(i) + "].ChdOcc",
                     dtype=str,
-                    if_nan='fill',
-                    value=CanadaFillna.Occupation_5257e.value
+                    if_nan="fill",
+                    value=CanadaFillna.Occupation_5257e.value,
                 )
                 # child's marriage status: int -> categorical
                 dataframe = self.change_dtype(
-                    col_name='p1.SecB.Chd.['+str(i)+'].ChdMStatus',
+                    col_name="p1.SecB.Chd.[" + str(i) + "].ChdMStatus",
                     dtype=np.int16,
-                    if_nan='fill',
-                    value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value)
+                    if_nan="fill",
+                    value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value),
                 )
                 # child's accompanying 01: coming=True or not_coming=False
-                dataframe['p1.SecB.Chd.['+str(i)+'].ChdAccomp'] = dataframe['p1.SecB.Chd.['+str(i)+'].ChdAccomp'].apply(
-                    lambda x: True if x == '1' else False)
+                dataframe["p1.SecB.Chd.[" + str(i) + "].ChdAccomp"] = dataframe[
+                    "p1.SecB.Chd.[" + str(i) + "].ChdAccomp"
+                ].apply(lambda x: True if x == "1" else False)
 
                 # check if the child does not exist and fill it properly (ghost case monkaS)
-                if (dataframe['p1.SecB.Chd.['+str(i)+'].ChdMStatus'] == CanadaFillna.ChildMarriageStatus_5645e.value).all() \
-                        and (dataframe['p1.SecB.Chd.['+str(i)+'].ChdRel'] == 'OTHER').all() \
-                        and (dataframe['p1.SecB.Chd.['+str(i)+'].ChdDOB'].isna()).all() \
-                        and (dataframe['p1.SecB.Chd.['+str(i)+'].ChdAccomp'] == False).all():
+                if (
+                    (
+                        dataframe["p1.SecB.Chd.[" + str(i) + "].ChdMStatus"]
+                        == CanadaFillna.ChildMarriageStatus_5645e.value
+                    ).all()
+                    and (
+                        dataframe["p1.SecB.Chd.[" + str(i) + "].ChdRel"] == "OTHER"
+                    ).all()
+                    and (dataframe["p1.SecB.Chd.[" + str(i) + "].ChdDOB"].isna()).all()
+                    and (
+                        dataframe["p1.SecB.Chd.[" + str(i) + "].ChdAccomp"] == False
+                    ).all()
+                ):
                     # ghost child's date of birth: None -> datetime (current date) -> 0 days
                     dataframe = self.change_dtype(
-                        col_name='p1.SecB.Chd.['+str(i)+'].ChdDOB',
+                        col_name="p1.SecB.Chd.[" + str(i) + "].ChdDOB",
                         dtype=parser.parse,
-                        if_nan='fill',
-                        value=dataframe['p1.SecC.SecCdate']
+                        if_nan="fill",
+                        value=dataframe["p1.SecC.SecCdate"],
                     )
 
             # siblings' status
             siblings_tag_list = [
-                c for c in dataframe.columns.values if 'p1.SecC.Chd' in c]
+                c for c in dataframe.columns.values if "p1.SecC.Chd" in c
+            ]
             SIBLINGS_MAX_FEATURES = 8
             for i in range(len(siblings_tag_list) // SIBLINGS_MAX_FEATURES):
                 # sibling's marriage status 01: string to integer
                 dataframe = self.change_dtype(
-                    col_name='p1.SecC.Chd.['+str(i)+'].ChdMStatus',
+                    col_name="p1.SecC.Chd.[" + str(i) + "].ChdMStatus",
                     dtype=np.int16,
-                    if_nan='fill',
-                    value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value)
+                    if_nan="fill",
+                    value=np.int16(CanadaFillna.ChildMarriageStatus_5645e.value),
                 )
                 # sibling's relationship 01: string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='p1.SecC.Chd.['+str(i)+'].ChdRel',
+                    col_name="p1.SecC.Chd.[" + str(i) + "].ChdRel",
                     dtype=str,
-                    if_nan='fill',
-                    value=CanadaFillna.ChildRelation_5645e.value
+                    if_nan="fill",
+                    value=CanadaFillna.ChildRelation_5645e.value,
                 )
                 # sibling's date of birth 01: string -> datetime
                 dataframe = self.change_dtype(
-                    col_name='p1.SecC.Chd.['+str(i)+'].ChdDOB',
+                    col_name="p1.SecC.Chd.[" + str(i) + "].ChdDOB",
                     dtype=parser.parse,
-                    if_nan='skip'
+                    if_nan="skip",
                 )
-                
+
                 # sibling's country of birth 01: string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='p1.SecC.Chd.['+str(i)+'].ChdCOB',
+                    col_name="p1.SecC.Chd.[" + str(i) + "].ChdCOB",
                     dtype=str,
-                    if_nan='fill',
-                    value=CanadaFillna.Country_5257e.value
+                    if_nan="fill",
+                    value=CanadaFillna.Country_5257e.value,
                 )
                 # sibling's occupation type 01 (issue #2): string -> categorical
                 dataframe = self.change_dtype(
-                    col_name='p1.SecC.Chd.['+str(i)+'].ChdOcc',
+                    col_name="p1.SecC.Chd.[" + str(i) + "].ChdOcc",
                     dtype=str,
-                    if_nan='fill',
-                    value=CanadaFillna.Occupation_5257e.value
+                    if_nan="fill",
+                    value=CanadaFillna.Occupation_5257e.value,
                 )
                 # sibling's accompanying: coming=True or not_coming=False
-                dataframe['p1.SecC.Chd.['+str(i)+'].ChdAccomp'] = dataframe['p1.SecC.Chd.['+str(i)+'].ChdAccomp'].apply(
-                    lambda x: True if x == '1' else False)
+                dataframe["p1.SecC.Chd.[" + str(i) + "].ChdAccomp"] = dataframe[
+                    "p1.SecC.Chd.[" + str(i) + "].ChdAccomp"
+                ].apply(lambda x: True if x == "1" else False)
 
                 # check if the sibling does not exist and fill it properly (ghost case monkaS)
-                if (dataframe['p1.SecC.Chd.['+str(i)+'].ChdMStatus'] == CanadaFillna.ChildMarriageStatus_5645e.value).all() \
-                        and (dataframe['p1.SecC.Chd.['+str(i)+'].ChdRel'] == 'OTHER').all() \
-                        and (dataframe['p1.SecC.Chd.['+str(i)+'].ChdOcc'].isna()).all() \
-                        and (dataframe['p1.SecC.Chd.['+str(i)+'].ChdAccomp'] == False).all():
+                if (
+                    (
+                        dataframe["p1.SecC.Chd.[" + str(i) + "].ChdMStatus"]
+                        == CanadaFillna.ChildMarriageStatus_5645e.value
+                    ).all()
+                    and (
+                        dataframe["p1.SecC.Chd.[" + str(i) + "].ChdRel"] == "OTHER"
+                    ).all()
+                    and (dataframe["p1.SecC.Chd.[" + str(i) + "].ChdOcc"].isna()).all()
+                    and (
+                        dataframe["p1.SecC.Chd.[" + str(i) + "].ChdAccomp"] == False
+                    ).all()
+                ):
                     # ghost sibling's date of birth: None -> datetime (current date) -> 0 days
                     dataframe = self.change_dtype(
-                        col_name='p1.SecC.Chd.['+str(i)+'].ChdDOB',
+                        col_name="p1.SecC.Chd.[" + str(i) + "].ChdDOB",
                         dtype=parser.parse,
-                        if_nan='fill',
-                        value=dataframe['p1.SecC.SecCdate']
+                        if_nan="fill",
+                        value=dataframe["p1.SecC.SecCdate"],
                     )
 
             return dataframe
 
         if type == DocTypes.canada_label:
-            dataframe = pd.read_csv(path, sep=' ', names=['VisaResult'])
+            dataframe = pd.read_csv(path, sep=" ", names=["VisaResult"])
             functional.change_dtype(
                 dataframe=dataframe,
-                col_name='VisaResult',
+                col_name="VisaResult",
                 dtype=np.int8,
-                if_nan='fill',
-                value=np.int8(CanadaFillna.VisaResult.value)
+                if_nan="fill",
+                value=np.int8(CanadaFillna.VisaResult.value),
             )
             return dataframe
 
@@ -1337,7 +1368,7 @@ class FileTransform:
 
         Args:
             src: source file to be processed
-            dst: the pass that the processed file to be saved 
+            dst: the pass that the processed file to be saved
         """
         pass
 
@@ -1356,16 +1387,16 @@ class CopyFile(FileTransform):
     def __init__(self, mode: str) -> None:
         super().__init__()
 
-        self.COPY_MODES = ['c', 'cf', 'c2']
-        self.mode = mode if mode is not None else 'cf'
+        self.COPY_MODES = ["c", "cf", "c2"]
+        self.mode = mode if mode is not None else "cf"
         self.__check_mode(mode=mode)
 
-    def __call__(self, src: str, dst: str,  *args: Any, **kwds: Any) -> Any:
-        if self.mode == 'c':
+    def __call__(self, src: str, dst: str, *args: Any, **kwds: Any) -> Any:
+        if self.mode == "c":
             shutil.copy(src=src, dst=dst)
-        elif self.mode == 'cf':
+        elif self.mode == "cf":
             shutil.copyfile(src=src, dst=dst)
-        elif self.mode == 'c2':
+        elif self.mode == "c2":
             shutil.copy2(src=src, dst=dst)
 
     def __check_mode(self, mode: str):
@@ -1377,8 +1408,9 @@ class CopyFile(FileTransform):
         .. _shutil: https://docs.python.org/3/library/shutil.html
         """
         if not mode in self.COPY_MODES:
-            raise ValueError((f'Mode {mode} does not exist,',
-                              f'choose one of "{self.COPY_MODES}".'))
+            raise ValueError(
+                (f"Mode {mode} does not exist,", f'choose one of "{self.COPY_MODES}".')
+            )
 
 
 class MakeContentCopyProtectedMachineReadable(FileTransform):
@@ -1419,7 +1451,7 @@ class FileTransformCompose:
     Transformation dictionary over files in the following structure::
 
         {
-            FileTransform: 'filter_str', 
+            FileTransform: 'filter_str',
             ...,
         }
 
@@ -1431,7 +1463,7 @@ class FileTransformCompose:
         """
 
         Args:
-            transforms: a dictionary of transforms, where the key is the instance of 
+            transforms: a dictionary of transforms, where the key is the instance of
                 FileTransform and the value is the keyword that the transform will be
                 applied to
 
@@ -1441,7 +1473,7 @@ class FileTransformCompose:
         if transforms is not None:
             for k in transforms.keys():
                 if not issubclass(k.__class__, FileTransform):
-                    raise TypeError(f'Keys must be {FileTransform} instance.')
+                    raise TypeError(f"Keys must be {FileTransform} instance.")
 
         self.transforms = transforms
 

--- a/cvfe/main.py
+++ b/cvfe/main.py
@@ -1,53 +1,56 @@
-# Ours: API
-from cvfe.api import models as api_models
-from cvfe.api import apps as api_apps
-from cvfe.api.convert.adobe_xfa import router as adobe_xfa_router
-# API
-import fastapi
-from fastapi.middleware.cors import CORSMiddleware
-import uvicorn
-# helpers
 import argparse
 import logging
 
+import fastapi
+import uvicorn
+from fastapi.middleware.cors import CORSMiddleware
+
+from cvfe.api import apps as api_apps
+from cvfe.api import models as api_models
+from cvfe.api.convert.adobe_xfa import router as adobe_xfa_router
 
 # argparse
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    '-v',
-    '--verbose',
+    "-v",
+    "--verbose",
     type=str,
-    help='logging verbosity level.',
-    choices=['debug', 'info'],
-    default='info',
-    required=False)
+    help="logging verbosity level.",
+    choices=["debug", "info"],
+    default="info",
+    required=False,
+)
 parser.add_argument(
-    '-b',
-    '--bind',
+    "-b",
+    "--bind",
     type=str,
-    help='ip address of host',
-    default='0.0.0.0',
-    required=True)
+    help="ip address of host",
+    default="0.0.0.0",
+    required=True,
+)
 parser.add_argument(
-    '-p',
-    '--port',
+    "-p",
+    "--port",
     type=int,
-    help='port used for creating the gunicorn server',
+    help="port used for creating the gunicorn server",
     default=8000,
-    required=True)
+    required=True,
+)
 parser.add_argument(
-    '-w',
-    '--workers',
+    "-w",
+    "--workers",
     type=int,
-    help='number of works used by gunicorn',
+    help="number of works used by gunicorn",
     default=1,
-    required=False)
+    required=False,
+)
 parser.add_argument(
-    '-u',
-    '--post-url',
+    "-u",
+    "--post-url",
     type=str,
-    help='URL of the third-party endpoint to send the post request',
-    required=False)
+    help="URL of the third-party endpoint to send the post request",
+    required=False,
+)
 args = parser.parse_args()
 
 # globals
@@ -63,29 +66,27 @@ app = fastapi.FastAPI()
 settings = api_apps.Settings()
 
 # fastapi cross origin
-origins = ['*']
+origins = ["*"]
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
     allow_credentials=True,
-    allow_methods=['*'],
-    allow_headers=['*'],
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 if settings.USE_NGROK:
-    api_apps.init_ngrok(
-        host=args.bind,
-        port=args.port)
+    api_apps.init_ngrok(host=args.bind, port=args.port)
 
 
 app.include_router(adobe_xfa_router)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     options = {
-        'bind': f'{args.bind}:{args.port}',
-        'workers': args.workers,
-        'worker_class': 'uvicorn.workers.UvicornWorker'
+        "bind": f"{args.bind}:{args.port}",
+        "workers": args.workers,
+        "worker_class": "uvicorn.workers.UvicornWorker",
     }
     # api_apps.StandaloneApplication(app=app, options=options).run()
     uvicorn.run(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,17 +12,18 @@
 import datetime
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../..'))
+
+sys.path.insert(0, os.path.abspath("../.."))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
-project = 'cvfe'
-copyright = f'{datetime.datetime.now().year}, Nikan Doosti'
-author = 'Nikan Doosti'
+project = "cvfe"
+copyright = f"{datetime.datetime.now().year}, Nikan Doosti"
+author = "Nikan Doosti"
 
 # The full version, including alpha/beta/rc tags
-version_file_path = '../../VERSION'
-with open(version_file_path, 'r') as version_file:
+version_file_path = "../../VERSION"
+with open(version_file_path, "r") as version_file:
     package_version = version_file.read().strip()
 release = package_version
 
@@ -30,37 +31,35 @@ release = package_version
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.autosummary',
-    'sphinx_autodoc_typehints',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
-    'sphinx.ext.coverage',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.ifconfig',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
-    'sphinx.ext.autosectionlabel',
-    'sphinx_copybutton',
-    'myst_parser',
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autosummary",
+    "sphinx_autodoc_typehints",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.ifconfig",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.autosectionlabel",
+    "sphinx_copybutton",
+    "myst_parser",
 ]
 
 napoleon_use_ivar = True
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [
-    '_build'
-]
+exclude_patterns = ["_build"]
 
 autosummary_generate = True
 
@@ -69,12 +68,12 @@ autosummary_generate = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'furo'
+html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Default options to an ..autoXXX directive.
 autodoc_default_options = {
@@ -89,19 +88,19 @@ autodoc_default_options = {
 autodoc_inherit_docstrings = True
 
 # sort docs based on source code
-autodoc_member_order = 'bysource'
+autodoc_member_order = "bysource"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'numpy': ('https://numpy.org/doc/stable', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'pypdf2': ('https://pypdf2.readthedocs.io/en/3.0.0/', None),
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "pypdf2": ("https://pypdf2.readthedocs.io/en/3.0.0/", None),
 }
 
 # This value contains a list of modules to be mocked up
 autodoc_mock_imports = [
-    'typing',
-    'fastapi',
-    'xmltodict',
+    "typing",
+    "fastapi",
+    "xmltodict",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,26 @@ include-package-data = true
 where = ["cvfe"]
 [tool.setuptools.package-data]
 mypkg = ["*.csv"]
+[tool.black]
+line-length = 88
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+[tool.isort]
+profile = "black"
+line_length = 88
+include_trailing_comma = true
 
 [project.urls]
 Homepage = "https://github.com/Nikronic/canada-visa-form-extraction"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dynamic = ["version"]
 version = {file = "VERSION"}
 
 [project.optional-dependencies]
+format = ["pre-commit>=3.6.0"]
 test = ["httpx>=0.24.1", "pytest>=7.4.0"]
 doc = [
     "sphinx>=7.1.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 from pytest import Parser
 
+
 def pytest_addoption(parser):
     """A hook to add custom command line options to pytest
 
     Args:
-        parser (:class:`pytest.Parser`): 
+        parser (:class:`pytest.Parser`):
     """
-    parser.addoption('--bind', action='store', default='0.0.0.0')
-    parser.addoption('--port', action='store', default='8000')
-    
+    parser.addoption("--bind", action="store", default="0.0.0.0")
+    parser.addoption("--port", action="store", default="8000")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,54 +1,48 @@
-# core
-from starlette.testclient import TestClient
-from fastapi import status
 import json
-# Ours: API
-from cvfe.main import app
-# helpers
 from pathlib import Path
 
+from fastapi import status
+from starlette.testclient import TestClient
+
+from cvfe.main import app
 
 # globals
 test_client = TestClient(app=app)
-ASSETS_PATH = Path('tests/assets')
-DUMMY_FILES_PATH = ASSETS_PATH / Path('dummy')
-FILLED_FILES_PATH = ASSETS_PATH / Path('filled')
- 
+ASSETS_PATH = Path("tests/assets")
+DUMMY_FILES_PATH = ASSETS_PATH / Path("dummy")
+FILLED_FILES_PATH = ASSETS_PATH / Path("filled")
+
 
 # some notes:
 #   1. no need to define headers for requests: for some reason it throws error in multipart
 
+
 def test_read_main():
-    response = test_client.get('/')
+    response = test_client.get("/")
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
 
 def test_bad_files():
     files = {
-        'form_5257': open(DUMMY_FILES_PATH / Path('dummy_1.pdf'), 'rb'),
-        'form_5645': open(DUMMY_FILES_PATH / Path('dummy_2.pdf'), 'rb')
+        "form_5257": open(DUMMY_FILES_PATH / Path("dummy_1.pdf"), "rb"),
+        "form_5645": open(DUMMY_FILES_PATH / Path("dummy_2.pdf"), "rb"),
     }
 
-    response = test_client.post(
-        url='/cvfe/v1/convert/adobe_xfa/',
-        files=files
-    )
+    response = test_client.post(url="/cvfe/v1/convert/adobe_xfa/", files=files)
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 def test_good_files():
     files = {
-        'form_5257': open(FILLED_FILES_PATH / Path('imm5257e_fake.pdf'), 'rb'),
-        'form_5645': open(FILLED_FILES_PATH / Path('imm5645e_fake.pdf'), 'rb')
+        "form_5257": open(FILLED_FILES_PATH / Path("imm5257e_fake.pdf"), "rb"),
+        "form_5645": open(FILLED_FILES_PATH / Path("imm5645e_fake.pdf"), "rb"),
     }
 
-    response = test_client.post(
-        url='/cvfe/v1/convert/adobe_xfa/',
-        files=files
-    )
+    response = test_client.post(url="/cvfe/v1/convert/adobe_xfa/", files=files)
 
     print(response.content)
     assert response.status_code == status.HTTP_200_OK
 
-    correct_response = open('tests/assets/filled/response_fake_correct.json', 'rb')
+    correct_response = open("tests/assets/filled/response_fake_correct.json", "rb")
     assert response.json() == json.load(correct_response)


### PR DESCRIPTION
## Summary
- **add `pre-commit` for formatting (`black` and `isort`)**: well, why do things manually when you can automate!
- **do `isort` and `black`**: apply `isort` and `black` on all existing files
- **fix `isort` and `black` conflict**: given that these two have conflicts, and I like `black`'s formatting more, the conflict has been resolved by giving the `black` profile to `isort`