### PR TITLE
remove `pandas` requirement

### DIFF
--- a/cvfe/data/functional.py
+++ b/cvfe/data/functional.py
@@ -23,7 +23,7 @@ import logging
 import os
 import re
 from fnmatch import fnmatch
-from typing import Any, Callable, Optional, cast
+from typing import Any, Callable, Iterable, Optional, cast
 
 import numpy as np
 import pandas as pd
@@ -36,6 +36,19 @@ from cvfe.data.preprocessor import FileTransformCompose
 # set logger
 logger = logging.getLogger(__name__)
 
+
+def drop(dictionary: dict[str, Any], keys: Iterable[str]) -> None:
+    """Takes a dictionary and removes ``keys`` from it
+
+    Args:
+        dictionary (dict[str, Any]): The dictionary to be processed
+        keys (Iterable[str]): An iterable of string as subset of keys.
+            If an item in ``keys`` is none existent in the dictionary,
+            it will just skip it.
+    """
+
+    for k in keys:
+        dictionary.pop(k, None)
 
 def dict_summarizer(
     d: dict,

--- a/cvfe/data/functional.py
+++ b/cvfe/data/functional.py
@@ -66,15 +66,15 @@ def fillna(original: Any, new: Any) -> Any:
 
 
 def dict_summarizer(
-    d: dict,
+    data_dict: dict[str, Any],
     cutoff_term: str,
     KEY_ABBREVIATION_DICT: dict = None,
     VALUE_ABBREVIATION_DICT: dict = None,
-) -> dict:
+) -> dict[str, Any]:
     """Takes a flattened dictionary and shortens its keys
 
     Args:
-        d (dict): The dictionary to be shortened
+        data_dict (dict[str, Any]): The dictionary to be shortened
         cutoff_term (str): The string that used to find in keys and remove anything behind it
         KEY_ABBREVIATION_DICT (dict, optional): A dictionary containing abbreviation
             mapping for keys. Defaults to None.
@@ -82,14 +82,14 @@ def dict_summarizer(
             mapping for values. Defaults to None.
 
     Returns:
-        dict:
+        dict[str, Any]:
             A dict with shortened keys by throwing away some part and using a
             abbreviation dictionary for both keys and values.
     """
 
     new_keys = {}
     new_values = {}
-    for k, v in d.items():
+    for k, v in data_dict.items():
         if KEY_ABBREVIATION_DICT is not None:
             new_k = k
             if cutoff_term in k:  # FIXME: cutoff part should be outside of abbreviation
@@ -120,24 +120,26 @@ def dict_summarizer(
 
     # return a new dictionary with updated values
     if KEY_ABBREVIATION_DICT is None:
-        new_keys = dict((key, key) for (key, _) in d.items())
+        new_keys = dict((key, key) for (key, _) in data_dict.items())
     if VALUE_ABBREVIATION_DICT is None:
-        new_values = dict((value, value) for (_, value) in d.items())
-    return dict((new_keys[key], new_values[value]) for (key, value) in d.items())
+        new_values = dict((value, value) for (_, value) in data_dict.items())
+    return dict(
+        (new_keys[key], new_values[value]) for (key, value) in data_dict.items()
+    )
 
 
-def dict_to_csv(d: dict, path: str) -> None:
+def dict_to_csv(data_dict: dict[str, Any], path: str) -> None:
     """Takes a flattened dictionary and writes it to a CSV file.
 
     Args:
-        d (dict): A dictionary
+        data_dict (dict[str, Any]): A dictionary to be saved
         path (str): Path to the output file (will be created if not exist)
     """
 
     with open(path, "w") as f:
-        w = csv.DictWriter(f, d.keys())
+        w = csv.DictWriter(f, data_dict.keys())
         w.writeheader()
-        w.writerow(d)
+        w.writerow(data_dict)
 
 
 def column_dropper(
@@ -506,19 +508,17 @@ def change_dtype(
 
 
 
-
-
-def flatten_dict(d: dict) -> dict:
+def flatten_dict(dictionary: dict[str, Any]) -> dict[str, Any]:
     """Takes a (nested) multilevel dictionary and flattens it
 
     Args:
-        d (dict): A dictionary (could be multilevel)
+        dictionary (dict[str, Any]): A dictionary (could be multilevel)
 
     References:
         1. https://stackoverflow.com/a/67744709/18971263
 
     Returns:
-        dict: Flattened dictionary where keys and values of returned dict are:
+        dict[str, Any]: Flattened dictionary where keys and values of returned dict are:
 
             * ``new_keys[i] = f'{old_leys[level]}.{old_leys[level+1]}.[...].{old_leys[level+n]}'``
             * ``new_value = old_value``
@@ -526,8 +526,8 @@ def flatten_dict(d: dict) -> dict:
     """
 
     def items():
-        if isinstance(d, dict):
-            for key, value in d.items():
+        if isinstance(dictionary, dict):
+            for key, value in dictionary.items():
                 # nested subtree
                 if isinstance(value, dict):
                     for subkey, subvalue in flatten_dict(value).items():
@@ -640,5 +640,4 @@ def extended_dict_get(
             )
         )
         return string
-
 

--- a/cvfe/data/functional.py
+++ b/cvfe/data/functional.py
@@ -50,6 +50,21 @@ def drop(dictionary: dict[str, Any], keys: Iterable[str]) -> None:
     for k in keys:
         dictionary.pop(k, None)
 
+
+def fillna(original: Any, new: Any) -> Any:
+    """Replaces an ``original`` value with a ``new`` if None
+
+    Args:
+        original (Any): Original value to be replaced if None
+        new (Any): The new value as replacement of ``original``
+
+    Returns:
+        Any: The new value
+    """
+
+    return new if original is None else original
+
+
 def dict_summarizer(
     d: dict,
     cutoff_term: str,

--- a/cvfe/data/pdf.py
+++ b/cvfe/data/pdf.py
@@ -141,7 +141,7 @@ class XFAPDF(PDFIO):
         Returns:
             dict: A flattened dictionary
         """
-        return functional.flatten_dict(d=d)
+        return functional.flatten_dict(dictionary=d)
 
     def xml_to_flattened_dict(self, xml: str) -> dict:
         """Takes a (nested) XML and converts it to a flattened dictionary

--- a/cvfe/data/preprocessor.py
+++ b/cvfe/data/preprocessor.py
@@ -64,49 +64,6 @@ class DataframePreprocessor:
             inplace=inplace,
         )
 
-    def fillna_datetime(
-        self,
-        col_base_name: str,
-        type: DocTypes,
-        one_sided: str | bool,
-        date: Optional[str] = None,
-        inplace: bool = False,
-    ) -> Optional[pd.DataFrame]:
-        """See :func:`cvfe.data.functional.fillna_datetime` for more details"""
-        if date is None:
-            date = T0
-
-        return functional.fillna_datetime(
-            dataframe=self.dataframe,
-            col_base_name=col_base_name,
-            one_sided=one_sided,
-            date=date,
-            inplace=inplace,
-            type=type,
-        )
-
-    def aggregate_datetime(
-        self,
-        col_base_name: str,
-        new_col_name: str,
-        type: DocTypes,
-        if_nan: Optional[str | Callable] = None,
-        one_sided: Optional[str] = None,
-        reference_date: Optional[str] = None,
-        current_date: Optional[str] = None,
-    ) -> pd.DataFrame:
-        """See :func:`cvfe.data.functional.aggregate_datetime` for more details"""
-        return functional.aggregate_datetime(
-            dataframe=self.dataframe,
-            col_base_name=col_base_name,
-            new_col_name=new_col_name,
-            one_sided=one_sided,
-            if_nan=if_nan,
-            type=type,
-            reference_date=reference_date,
-            current_date=current_date,
-        )
-
     def file_specific_basic_transform(self, type: DocTypes, path: str) -> pd.DataFrame:
         """
         Takes a specific file then does data type fixing, missing value filling, discretization, etc.

--- a/cvfe/data/preprocessor.py
+++ b/cvfe/data/preprocessor.py
@@ -106,10 +106,9 @@ class DataframePreprocessor:
             path (str): string path to config file
         """
 
-        config_df = pd.read_csv(path)
-        return dict(
-            zip(config_df[config_df.columns[0]], config_df[config_df.columns[1]])
-        )
+        with open(path, newline="") as f:
+            config_dict = csv.DictReader(f, delimiter=",")
+        return config_dict
 
 
 class CanadaDataframePreprocessor(DataframePreprocessor):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "xmltodict>=0.13.0",
     "pikepdf>=8.2.1",
     "pypdf>=3.17.0",
+    "python-dateutil>=2.8.1",
     "pydantic>=2.0.3",
     "fastapi>=0.100.0",
     "gunicorn>=21.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
 requires-python = ">=3.10.6"
 dependencies = [
     "pip>=23.1.2",
-    "pandas>=1.5.3",
     "xmltodict>=0.13.0",
     "pikepdf>=8.2.1",
     "pypdf>=3.17.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pip>=23.1.2
-pandas>=1.5.3
 xmltodict>=0.13.0
 pikepdf>=8.2.1
 pypdf>=3.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pip>=23.1.2
 xmltodict>=0.13.0
 pikepdf>=8.2.1
 pypdf>=3.17.0
+python-dateutil>=2.8.1
 pydantic>=2.0.3
 fastapi>=0.100.0
 gunicorn>=21.2.0


### PR DESCRIPTION
## Intro
There was no reason to have such as large dependency (`pandas` leading to `numpy` and so on) for just such as simple reading and preprocessing. Hence, it needed to be removed. But given that all things were written based on Pandas `DataFrame`, the change is not as easy as it should. Transition from `DataFrame` to python `dict` is something affecting the entire code base.

## Summary
- **remove unused functions**: Removed all functions that are not used at all (copied over from other projects) and its wrappers used in `preprocessors` module
- **add pandas equivalent of `drop` for `dict`s**: instead of using `pandas.dataframe.drop` now we have the same function but for python dictionaries.
- **add pandas equivalent of `fillna` for `dict`s**: instead of using `pandas.dataframe.fillna` now we have the same function but for python dictionaries.
- **replace pandas `csv` writer with `csv` module**: For some reason, even writing/reading to a `csv` file was using Pandas. This is now replaced with python standard library `csv` package.
- **increase readability by renaming and typing**:
    1. Changed some variables names to sth better: `d` -> `dictionary` 
    2. Added typing and sub-typing: `dict` -> `dict[str, Any]`
- **convert all pandas `DataFrame` functions to `dict`**: change every single function to get a dictionary, manipulate it and return it in all cases instead of using pandas `DataFrame`
- **reflect `DataFrame` to `dict` in all usages**: Reflect the change in previous step in all modules/packages/etc that were using those pandas based functions. Now, all usages also working with `dict` instead of `DataFrame`.
- **removed `pandas` from requirements**: Since we no longer need pandas, we have removed it from the requirements (and `pyproject`)