### PR TITLE
Fix #49: Fix deprecation in GitHub action workflows

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -29,10 +29,10 @@ jobs:
         run: |
           if [[ ${{ github.event.pull_request.base.ref }} == "main" && ${{ github.event.pull_request.head.ref }} =~ ^release-v.*$ ]]; then
             echo "PR is from a release branch to main."
-            echo "::set-output name=trigger_deploy::true"
+            echo "trigger_deploy=true" >> $GITHUB_OUTPUT
           else
             echo "PR is not from a release branch to main."
-            echo "::set-output name=trigger_deploy::false"
+            echo "trigger_deploy=false" >> $GITHUB_OUTPUT
           fi
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Summary
**use Environment Files instead of `set-output` cmd**: This is the warning given by GitHub action: "Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information, see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"

The aforementioned blog has all we need, and simply we just needed to replace:

```shell
echo "::set-output name=trigger_deploy::true"
```

with 

```shell
echo "trigger_deploy=true" >> $GITHUB_OUTPUT
```