### PR TITLE
add cache to all python installs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+          cache: 'pip'
       - name: install package and docs optional dependencies
         run: pip install .[doc]
       - name: build docs

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,6 +17,7 @@ jobs:
           uses: actions/setup-python@v4
           with:
             python-version: "3.x"
+            cache: 'pip'
         
         - name: Install pypa/build
           run: >-
@@ -50,6 +51,7 @@ jobs:
           uses: actions/setup-python@v4
           with:
             python-version: "3.x"
+            cache: 'pip'
         
         - name: Install pypa/build
           run: >-

--- a/.github/workflows/test-build-docs.yml
+++ b/.github/workflows/test-build-docs.yml
@@ -15,5 +15,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
+          cache: 'pip'
       - name: install package and docs optional dependencies
         run: pip install .[doc]


### PR DESCRIPTION
Just caching of github actions thanks to existing workflows https://github.com/actions/setup-python. Since our installtion of python uses `pip`, the following would work just fine:

```yaml
steps:
- uses: actions/checkout@v4
- uses: actions/setup-python@v5
  with:
    python-version: '3.9'
    cache: 'pip' # caching pip dependencies
- run: pip install -r requirements.txt
```