### PR TITLE
separate conversion process from API

### DIFF
--- a/src/cvfe/api/convert/adobe_xfa.py
+++ b/src/cvfe/api/convert/adobe_xfa.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 from pathlib import Path
 from typing import Any, Optional
@@ -9,14 +8,7 @@ import requests
 from fastapi.encoders import jsonable_encoder
 
 from cvfe.api.convert import BASE_SOURCE_DIR
-from cvfe.data import functional
-from cvfe.data.constant import DocTypes
-from cvfe.data.preprocessor import (
-    CanadaDataDictPreprocessor,
-    CopyFile,
-    FileTransformCompose,
-    MakeContentCopyProtectedMachineReadable,
-)
+from cvfe.convert.adobe_xfa import process
 
 # config logger
 logger = logging.getLogger(__name__)
@@ -24,64 +16,6 @@ logger = logging.getLogger(__name__)
 
 # FastAPI router to be used by the FastAPI app
 router = fastapi.APIRouter(prefix="/cvfe/v1/convert/adobe_xfa", tags=["adobe_xfa"])
-
-
-def process(src_dir: Path):
-    # path to the output decrypted pdf
-    dst_dir: Path = src_dir.parts[0] / Path("decrypted/")
-    # main code
-    logger.info("↓↓↓ Starting data extraction ↓↓↓")
-    # Canada protected PDF to make machine readable and skip other files
-    compose = {
-        CopyFile(mode="cf"): ".csv",
-        CopyFile(mode="cf"): ".txt",
-        MakeContentCopyProtectedMachineReadable(): ".pdf",
-    }
-    file_transform_compose = FileTransformCompose(transforms=compose)
-    functional.process_directory(
-        src_dir=src_dir.as_posix(),
-        dst_dir=dst_dir.as_posix(),
-        compose=file_transform_compose,
-        file_pattern="*",
-    )
-    logger.info("↑↑↑ Finished data extraction ↑↑↑")
-
-    logger.info("↓↓↓ Starting data loading ↓↓↓")
-    # convert PDFs to dictionaries
-    src_dir = dst_dir.as_posix()
-    data_dict = {}
-    for dirpath, dirnames, all_filenames in os.walk(src_dir):
-        # filter all_filenames
-        filenames = all_filenames
-        if filenames:
-            files = [os.path.join(dirpath, fname) for fname in filenames]
-            # applicant form
-            logger.info("↓↓↓ Starting to process 5257E ↓↓↓")
-            in_fname = [f for f in files if "5257" in f][0]
-            data_dict_preprocessor = CanadaDataDictPreprocessor()
-            if len(in_fname) != 0:
-                data_dict_applicant = (
-                    data_dict_preprocessor.file_specific_basic_transform(
-                        path=in_fname, doc_type=DocTypes.CANADA_5257E
-                    )
-                )
-            logger.info("↑↑↑ Finished processing 5257E ↑↑↑")
-            # applicant family info
-            logger.info("↓↓↓ Starting to process 5645E ↓↓↓")
-            in_fname = [f for f in files if "5645" in f][0]
-            if len(in_fname) != 0:
-                data_dict_family = data_dict_preprocessor.file_specific_basic_transform(
-                    path=in_fname, doc_type=DocTypes.CANADA_5645E
-                )
-            logger.info("↑↑↑ Finished processing 5645E ↑↑↑")
-
-            # final dictionary: concatenate 5257 and 5645 dicts
-            data_dict.update(data_dict_applicant)
-            data_dict.update(data_dict_family)
-        # logging
-        logger.info(f"Processed the data point")
-    logger.info("↑↑↑ Finished data loading ↑↑↑")
-    return data_dict
 
 
 @router.post("/", status_code=fastapi.status.HTTP_200_OK, tags=["adobe_xfa"])

--- a/src/cvfe/convert/adobe_xfa.py
+++ b/src/cvfe/convert/adobe_xfa.py
@@ -1,0 +1,111 @@
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from cvfe.data import functional
+from cvfe.data.constant import DocTypes
+from cvfe.data.preprocessor import (
+    CanadaDataDictPreprocessor,
+    CopyFile,
+    FileTransformCompose,
+    MakeContentCopyProtectedMachineReadable,
+)
+
+# config logger
+logger = logging.getLogger(__name__)
+
+
+def process(src_dir: Path | str) -> dict[str, Any]:
+    """Converts a directory of 5257E and 5645E Canada visa forms to python dict
+
+    Note:
+        The structure of the src_dir must be::
+
+        some/path/
+            └── src_dir
+                ├── *5257*.pdf
+                └── *5645*.pdf
+
+    Note:
+        For more information about the details of implementation, please see
+        other modules such as:
+
+            - :mod:`cvfe.api`: for API requests if using one
+            - :mod:`cvfe.configs`: Contains external data
+            - :mod:`cvfe.data`: contains all reading/preprocessing and so on
+
+    Note:
+        If you are using the API endpoints, you can find this function on
+        ``/cvfe/v1/convert/adobe_xfa``
+
+    Args:
+        src_dir (Path): The path to the directory containing a set of 5257E and
+            5645E forms. This forms must be the official forms (Adobe protected).
+            Also, the files must contain ``5257`` or ``5645`` in their name to be
+            recognized.
+
+    Returns:
+        dict[str, Any]:
+            A dictionary where keys are the fields on the form and
+            values are the values non-transformed from the fields of the forms.
+    """
+    # convert str to Path
+    if isinstance(src_dir, str):
+        src_dir = Path(src_dir)
+
+    # path to the output decrypted pdf
+    dst_dir: Path = src_dir.parts[0] / Path("decrypted/")
+    # main code
+    logger.info("↓↓↓ Starting data extraction ↓↓↓")
+    # Canada protected PDF to make machine readable and skip other files
+    compose = {
+        CopyFile(mode="cf"): ".csv",
+        CopyFile(mode="cf"): ".txt",
+        MakeContentCopyProtectedMachineReadable(): ".pdf",
+    }
+    file_transform_compose = FileTransformCompose(transforms=compose)
+    functional.process_directory(
+        src_dir=src_dir.as_posix(),
+        dst_dir=dst_dir.as_posix(),
+        compose=file_transform_compose,
+        file_pattern="*",
+    )
+    logger.info("↑↑↑ Finished data extraction ↑↑↑")
+
+    logger.info("↓↓↓ Starting data loading ↓↓↓")
+    # convert PDFs to dictionaries
+    src_dir = dst_dir.as_posix()
+    data_dict: dict[str, Any] = {}
+    for dirpath, dirnames, all_filenames in os.walk(src_dir):
+        # filter all_filenames
+        filenames = all_filenames
+        if filenames:
+            files = [os.path.join(dirpath, fname) for fname in filenames]
+            # applicant form
+            logger.info("↓↓↓ Starting to process 5257E ↓↓↓")
+            in_fname = [f for f in files if "5257" in f][0]
+            data_dict_preprocessor = CanadaDataDictPreprocessor()
+            if len(in_fname) != 0:
+                data_dict_applicant = (
+                    data_dict_preprocessor.file_specific_basic_transform(
+                        path=in_fname, doc_type=DocTypes.CANADA_5257E
+                    )
+                )
+            logger.info("↑↑↑ Finished processing 5257E ↑↑↑")
+            # applicant family info
+            logger.info("↓↓↓ Starting to process 5645E ↓↓↓")
+            in_fname = [f for f in files if "5645" in f][0]
+            if len(in_fname) != 0:
+                data_dict_family = data_dict_preprocessor.file_specific_basic_transform(
+                    path=in_fname, doc_type=DocTypes.CANADA_5645E
+                )
+            logger.info("↑↑↑ Finished processing 5645E ↑↑↑")
+
+            # final dictionary: concatenate 5257 and 5645 dicts
+            data_dict.update(data_dict_applicant)
+            data_dict.update(data_dict_family)
+        # logging
+        logger.info(f"Processed the data point")
+    logger.info("↑↑↑ Finished data loading ↑↑↑")
+    return data_dict


### PR DESCRIPTION
## Summary
Previously, the `api` module was hosting the processing (the actual work) too. So if someone wanted to use just the SDK, would have run into issue if didn't have `api` dependencies. Now, module `cvfe.convert` contains the functionality or the actual work, and `api` just contains a wrapper around it via `fastapi`. (see #59 on effort to make the package SDK friendly)