### PR TITLE
fix not using relative path and only part of it when processing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ cython_debug/
 sample/
 # ignore `temp` dir of API
 temp/
+
+# test generated files for decrypted pdfs
+tests/assets/decrypted

--- a/src/cvfe/convert/adobe_xfa.py
+++ b/src/cvfe/convert/adobe_xfa.py
@@ -55,7 +55,7 @@ def process(src_dir: Path | str) -> dict[str, Any]:
         src_dir = Path(src_dir)
 
     # path to the output decrypted pdf
-    dst_dir: Path = src_dir.parts[0] / Path("decrypted/")
+    dst_dir: Path = src_dir.parent / Path("decrypted/")
     # main code
     logger.info("↓↓↓ Starting data extraction ↓↓↓")
     # Canada protected PDF to make machine readable and skip other files


### PR DESCRIPTION
## Summary
- **fix not using relative path and only part of it**: now all decrypted files generated from code are located right next to directory of original files.
- **ignore decrypted files generated by tests**